### PR TITLE
add npm scripts for start and env

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,17 @@ $ npm install -g lab
 3) Copy the distributed environment file via command line, or manually using a code editor:
 
 ```
-$ cp env.dist .env
+$ npm run env
+
+OR, if you are on Windows
+
+$ COPY env.dist .env
 ```
 
 4) Run the server at the default log level (`'info'`):
 
 ```
-$ node app
+$ npm start
 ```
 
 The server's log level can be set in the environment or the .env file using `LOG_LEVEL=*` with one of `fatal`, `error`, `warn`, `info`, `debug`, `trace`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "A server to save and publish makes/projects created on Thimble and X-ray Goggles",
   "main": "app.js",
   "scripts": {
+    "start": "node app",
+    "env": "cp env.dist .env",
     "test": "lab"
   },
   "repository": {


### PR DESCRIPTION
npm scripts are a great way to "self-document" the steps needed to get the project up and running. reading the `package.json` can obviate the need for a `README`, this way, in a sense. 

(not that i think we should get rid of the `README`)