### PR TITLE
Fixed #94 - Made update operations return 200 if nothing was modified

### DIFF
--- a/api/classes/base_controller.js
+++ b/api/classes/base_controller.js
@@ -36,7 +36,7 @@ BaseController.prototype.update = function(req, reply) {
 
     record.set(reqData);
     if (!record.hasChanged()) {
-      throw Boom.notFound();
+      return record;
     }
 
     return record

--- a/test/api/handlers/users/update.js
+++ b/test/api/handlers/users/update.js
@@ -95,4 +95,46 @@ experiment('[Update a user by id]', function() {
       done();
     });
   });
+
+  test('returns a 200 when nothing is updated', function(done) {
+    server.inject({
+      url: '/users',
+      method: 'post',
+      payload: {
+        name: 'TestUser'
+      },
+      headers: {
+        authorization: 'token TestUser'
+      }
+    }, function(resp) {
+      expect(resp.statusCode).to.equal(201);
+
+      server.inject({
+        url: '/users/' + resp.result.id,
+        method: 'put',
+        payload: {
+          name: 'TestUser'
+        },
+        headers: {
+          authorization: 'token TestUser'
+        }
+      }, function(resp) {
+        expect(resp.statusCode).to.equal(200);
+        expect(resp.result).to.exist();
+        expect(resp.result.id).to.be.a.number();
+        expect(resp.result.name).to.be.a.string();
+
+        server.inject({
+          url: '/users/' + resp.result.id,
+          method: 'delete',
+          headers: {
+            authorization: 'token TestUser'
+          }
+        }, function (resp) {
+          expect(resp.statusCode).to.equal(204);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Because the test suite is cumbersome to update, I added a single test case for this behaviour. Since all implementations lean on the `base_controller` update method, this is sufficient to prove that it behaves properly.