### PR TITLE
Fix Content-Type for IE so decompression works for tarballs

### DIFF
--- a/api/classes/base_controller.js
+++ b/api/classes/base_controller.js
@@ -107,8 +107,10 @@ BaseController.prototype.getAllAsTar = function(req, reply) {
     });
   }
 
+  // Normally this type would be application/x-tar, but IE refuses to
+  // decompress a gzipped stream when this is the type.
   return reply(createTarStream())
-    .header('Content-Type', 'application/x-tar');
+    .header('Content-Type', 'application/octet-stream');
 };
 
 


### PR DESCRIPTION
Same fix we did for Thimble in https://github.com/mozilla/thimble.webmaker.org/issues/1064, where we switched away from `application/x-tar` for the `content-type` on a tarball in favour of `application/octet-stream` so that IE will properly decompress the stream in the browser. 