### PR TITLE
Schema retry

### DIFF
--- a/api/modules/projects/controller.js
+++ b/api/modules/projects/controller.js
@@ -18,7 +18,9 @@ controller.formatRequestData = function(req) {
     tags: req.payload.tags,
     description: req.payload.description,
     date_created: req.payload.date_created,
-    date_updated: req.payload.date_updated
+    date_updated: req.payload.date_updated,
+    readonly: req.payload.readonly,
+    client: req.payload.client
   };
   if (req.params.id) {
     data.id = parseInt(req.params.id);

--- a/api/modules/projects/schema.js
+++ b/api/modules/projects/schema.js
@@ -7,5 +7,7 @@ module.exports = Joi.object().keys({
   date_updated: Joi.string().required(),
   description: Joi.string().allow('').allow(null),
   tags: Joi.string().allow(null),
-  published_id: Joi.number().allow(null)
+  published_id: Joi.number().allow(null),
+  readonly: Joi.boolean().allow(null),
+  client: Joi.string().allow(null)
 });

--- a/knexfile.js
+++ b/knexfile.js
@@ -17,8 +17,8 @@ module.exports = {
     client: 'pg',
     debug: process.env.DEBUG == true,
     connection: process.env.DATABASE_URL,
-    directory: path.resolve(__dirname, '../migrations'),
     migrations: {
+      directory: path.resolve(__dirname, 'migrations'),
       tableName: 'migrations'
     }
   }

--- a/migrations/1_create_users_projects_files.js
+++ b/migrations/1_create_users_projects_files.js
@@ -1,84 +1,55 @@
-var Promise = require('bluebird');
+'use strict';
 
-exports.up = function (knex) {
-  return knex.schema
-  .createTable('publishedProjects', function(t) {
-    t.increments('id');
-    t.text('title').notNullable();
-    t.text('tags');
-    t.text('description');
+exports.up = function (knex, Promise) {
+  return Promise.resolve()
+  .then(function() {
+    return knex.schema.createTable('publishedProjects', function(t) {
+      t.increments('id');
+      t.text('title').notNullable();
+      t.text('tags');
+      t.text('description');
+    });
   })
-  .createTable('users', function (t) {
-    t.increments('id');
-    t.text('name').notNullable().unique();
+  .then(function() {
+    return knex.schema.createTable('users', function (t) {
+      t.increments('id');
+      t.text('name').notNullable().unique();
+    });
   })
-  .createTable('projects', function (t) {
-    t.increments('id');
-    t.integer('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
-    t.integer('published_id').references('id').inTable('publishedProjects');
-    t.text('title').notNullable();
-    t.text('tags');
-    t.text('description');
-    t.text('publish_url');
-    t.text('date_created').notNullable();
-    t.text('date_updated').notNullable();
+  .then(function() {
+    return knex.schema.createTable('projects', function (t) {
+      t.increments('id');
+      t.integer('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+      t.integer('published_id').references('id').inTable('publishedProjects');
+      t.text('title').notNullable();
+      t.text('tags');
+      t.text('description');
+      t.text('publish_url');
+      t.text('date_created').notNullable();
+      t.text('date_updated').notNullable();
+    });
   })
-  .createTable('files', function (t) {
-    t.increments('id');
-    t.integer('project_id').notNullable().references('id').inTable('projects').onDelete('CASCADE');
-    t.text('path').notNullable();
-    t.specificType('buffer', 'bytea').notNullable();
+  .then(function() {
+    return knex.schema.createTable('files', function (t) {
+      t.increments('id');
+      t.integer('project_id').notNullable().references('id').inTable('projects').onDelete('CASCADE');
+      t.text('path').notNullable();
+      t.specificType('buffer', 'bytea').notNullable();
+    });
   })
-  .createTable('publishedFiles', function(t) {
-    t.increments('id');
-    t.integer('published_id').notNullable().references('id').inTable('publishedProjects').onDelete('CASCADE');
-    t.integer('file_id').references('id').inTable('files');
-    t.text('path').notNullable();
-    t.specificType('buffer', 'bytea').notNullable();
+  .then(function() {
+    return knex.schema.createTable('publishedFiles', function(t) {
+      t.increments('id');
+      t.integer('published_id').notNullable().references('id').inTable('publishedProjects').onDelete('CASCADE');
+      t.integer('file_id').references('id').inTable('files');
+      t.text('path').notNullable();
+      t.specificType('buffer', 'bytea').notNullable();
+    });
   });
 };
 
 
-exports.down = function (knex) {
-  return Promise.resolve()
-  .then(function() {
-    return knex.schema.hasTable('users')
-    .then(function(exists) {
-      if (exists) {
-        return knex.raw('DROP TABLE users CASCADE');
-      }
-    });
-  })
-  .then(function() {
-    return knex.schema.hasTable('projects')
-    .then(function(exists) {
-      if (exists) {
-        return knex.raw('DROP TABLE projects CASCADE');
-      }
-    });
-  })
-  .then(function() {
-    return knex.schema.hasTable('files')
-    .then(function(exists) {
-      if (exists) {
-        return knex.raw('DROP TABLE files CASCADE');
-      }
-    });
-  })
-  .then(function() {
-    return knex.schema.hasTable('publishedProjects')
-    .then(function(exists) {
-      if (exists) {
-        return knex.raw('DROP TABLE "publishedProjects" CASCADE');
-      }
-    });
-  })
-  .then(function() {
-    return knex.schema.hasTable('publishedFiles')
-    .then(function(exists) {
-      if (exists) {
-        return knex.raw('DROP TABLE "publishedFiles"');
-      }
-    });
-  });
+exports.down = function (knex, Promise) {
+  // Irreversible, as this can lead to permanent data loss.
+  return Promise.resolve();
 };

--- a/migrations/2_add_readonly_client_columns.js
+++ b/migrations/2_add_readonly_client_columns.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return Promise.join(
+    knex.schema.table('projects', function (t) {
+      t.boolean('_readonly');
+      t.text('_client');
+    })
+  );
+};
+
+exports.down = function (knex, Promise) {
+  // Irreversible, as this can lead to permanent data loss.
+  return Promise.resolve();
+};

--- a/migrations/3_toggle_readonly_client_columns.js
+++ b/migrations/3_toggle_readonly_client_columns.js
@@ -1,0 +1,21 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  // "Enable" the readonly and client columns.
+  return Promise.join(
+    knex.schema.table('projects', function (t) {
+      t.renameColumn('_readonly', 'readonly');
+      t.renameColumn('_client', 'client');
+    })
+  );
+};
+
+exports.down = function (knex, Promise) {
+  // "Disable" the readonly and client columns.
+  return Promise.join(
+    knex.schema.table('projects', function (t) {
+      t.renameColumn('readonly', '_readonly');
+      t.renameColumn('client', '_client');
+    })
+  );
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "node server",
     "env": "cp env.dist .env",
-    "knex": "knex migrate:latest && knex seed:run",
+    "knex": "npm run migrate && npm run seed",
+    "migrate": "knex migrate:latest",
+    "seed": "knex seed:run",
     "test": "npm run knex && lab -t 80 -c --verbose --colors --assert code --timeout 5000 && npm run lint",
     "lint": "npm run jshint && npm run jscs",
     "jshint": "jshint -c node_modules/mofo-style/linters/.jshintrc api migrations seeds lib adaptors test server.js",

--- a/seeds/1_users.js
+++ b/seeds/1_users.js
@@ -1,13 +1,9 @@
 'use strict';
 
-var dropTables = require('../migrations/1_create_users_projects_files').down;
-var createTables = require('../migrations/1_create_users_projects_files').up;
-
 exports.seed = function(knex, Promise) {
-  return dropTables(knex)
-    .then(function() { return createTables(knex); })
-
-    .then(function() { return knex('users').insert({ name: 'ag-dubs' }); })
-    .then(function() { return knex('users').insert({ name: 'k88hudson' }); })
-    .then(function() { return knex('users').insert({ name: 'jbuckca' }); });
+  return Promise.join(
+    knex('users').insert({ name: 'ag-dubs' }),
+    knex('users').insert({ name: 'k88hudson' }),
+    knex('users').insert({ name: 'jbuckca' })
+  );
 };

--- a/seeds/2_projects.js
+++ b/seeds/2_projects.js
@@ -16,7 +16,8 @@ exports.seed = function(knex, Promise) {
       tags: 'ruby, sinatra, community, utilities',
       description: 'Hydrogen atoms Sea of Tranquility are creatures of the cosmos shores of the cosmic ocean.',
       date_created: '2015-06-03T13:21:58+00:00',
-      date_updated: '2015-06-03T13:21:58+00:00'
+      date_updated: '2015-06-03T13:21:58+00:00',
+      readonly: true
     }),
     knex('projects').insert({
       user_id: 2,
@@ -25,7 +26,8 @@ exports.seed = function(knex, Promise) {
       description: 'Gathered by gravity encyclopaedia galactica permanence of ' +
         'the stars made in the interiors of collapsing stars! ',
       date_created: '2015-06-03T13:21:58+00:00',
-      date_updated: '2015-06-03T13:21:58+00:00'
+      date_updated: '2015-06-03T13:21:58+00:00',
+      client: 'webmaker-android'
     }),
     knex('projects').insert({
       user_id: 3,
@@ -34,7 +36,9 @@ exports.seed = function(knex, Promise) {
       description: 'Orions sword a still more glorious dawn awaits at the edge ' +
         'of forever consciousness, cosmic fugue Vangelis, globular star cluster.',
       date_created: '2015-06-03T13:21:58+00:00',
-      date_updated: '2015-06-03T13:21:58+00:00'
+      date_updated: '2015-06-03T13:21:58+00:00',
+      readonly: true,
+      client: 'makedrive'
     })
   );
 };

--- a/test/api/handlers/projects/create.js
+++ b/test/api/handlers/projects/create.js
@@ -41,6 +41,9 @@ experiment('[Create a project]', function() {
       expect(resp.result.date_updated).to.be.a.string();
       expect(resp.result.title).to.be.a.string();
       expect(resp.result.tags).to.be.a.string();
+      expect(resp.result.readonly).to.be.a.boolean();
+      expect(resp.result.client).to.be.a.string();
+
 
       server.inject({
         url: '/projects/' + resp.result.id,

--- a/test/lib/fixtures/projects/create.js
+++ b/test/lib/fixtures/projects/create.js
@@ -31,7 +31,9 @@ module.exports = function(cb) {
           date_created: '01/01/15',
           date_updated: '01/01/15',
           description: 'A test project',
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       }
     };
@@ -47,7 +49,9 @@ module.exports = function(cb) {
           date_created: '01/01/15',
           date_updated: '01/01/15',
           description: 'A test project',
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       },
 
@@ -61,7 +65,9 @@ module.exports = function(cb) {
           date_created: '01/01/15',
           date_updated: '01/01/15',
           description: 'A test project',
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       },
       titleTypeError: {
@@ -74,7 +80,9 @@ module.exports = function(cb) {
           date_created: '01/01/15',
           date_updated: '01/01/15',
           description: 'A test project',
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       },
       dateCreatedTypeError: {
@@ -87,7 +95,9 @@ module.exports = function(cb) {
           date_created: 123,
           date_updated: '01/01/15',
           description: 'A test project',
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       },
       dateUpdatedTypeError: {
@@ -100,7 +110,9 @@ module.exports = function(cb) {
           date_created: '01/01/15',
           date_updated: 123,
           description: 'A test project',
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       },
       descriptionTypeError: {
@@ -113,7 +125,9 @@ module.exports = function(cb) {
           date_created: '01/01/15',
           date_updated: '01/01/15',
           description: 123,
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       },
       tagsTypeError: {
@@ -126,7 +140,39 @@ module.exports = function(cb) {
           date_created: '01/01/15',
           date_updated: '01/01/15',
           description: 'A test project',
-          tags: 123
+          tags: 123,
+          readonly: false,
+          client: 'test runner'
+        }
+      },
+      readonlyTypeError: {
+        headers: userToken,
+        url: '/projects',
+        method: 'post',
+        payload: {
+          title: 'Test project',
+          user_id: validUsers[0].id,
+          date_created: '01/01/15',
+          date_updated: '01/01/15',
+          description: 'A test project',
+          tags: 'test, project, foo, whiz',
+          readonly: 12345,
+          client: 'test runner'
+        }
+      },
+      clientTypeError: {
+        headers: userToken,
+        url: '/projects',
+        method: 'post',
+        payload: {
+          title: 'Test project',
+          user_id: validUsers[0].id,
+          date_created: '01/01/15',
+          date_updated: '01/01/15',
+          description: 'A test project',
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 12345
         }
       },
 
@@ -145,7 +191,9 @@ module.exports = function(cb) {
           date_created: '01/01/15',
           date_updated: '01/01/15',
           description: 'A test project',
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       },
       titleAbsent: {
@@ -157,7 +205,9 @@ module.exports = function(cb) {
           date_created: '01/01/15',
           date_updated: '01/01/15',
           description: 'A test project',
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       },
       dateCreatedAbsent: {
@@ -169,7 +219,9 @@ module.exports = function(cb) {
           user_id: validUsers[0].id,
           date_updated: '01/01/15',
           description: 'A test project',
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       },
       dateUpdatedAbsent: {
@@ -181,7 +233,9 @@ module.exports = function(cb) {
           user_id: validUsers[0].id,
           date_created: '01/01/15',
           description: 'A test project',
-          tags: 'test, project, foo, whiz'
+          tags: 'test, project, foo, whiz',
+          readonly: false,
+          client: 'test runner'
         }
       },
       tagsAbsent: {
@@ -193,7 +247,37 @@ module.exports = function(cb) {
           user_id: validUsers[0].id,
           date_created: '01/01/15',
           date_updated: '01/01/15',
-          description: 'A test project'
+          description: 'A test project',
+          readonly: false,
+          client: 'test runner'
+        }
+      },
+      readonlyAbsent: {
+        headers: userToken,
+        url: '/projects',
+        method: 'post',
+        payload: {
+          title: 'Test project',
+          user_id: validUsers[0].id,
+          date_created: '01/01/15',
+          date_updated: '01/01/15',
+          description: 'A test project',
+          tags: 'test, project, foo, whiz',
+          client: 'test runner'
+        }
+      },
+      clientAbsent: {
+        headers: userToken,
+        url: '/projects',
+        method: 'post',
+        payload: {
+          title: 'Test project',
+          user_id: validUsers[0].id,
+          date_created: '01/01/15',
+          date_updated: '01/01/15',
+          description: 'A test project',
+          tags: 'test, project, foo, whiz',
+          readonly: false
         }
       }
     };


### PR DESCRIPTION
fixes https://github.com/mozilla/publish.webmaker.org/issues/159
fixes https://github.com/mozilla/publish.webmaker.org/issues/163

Adds a `readonly` and `client` column to the "projects" table, so that clients can indicate who they are, and tools can see what kind of operations might be allowed based on the readonly flag.