### PR TITLE
Honour readonly

### DIFF
--- a/api/classes/publisher.js
+++ b/api/classes/publisher.js
@@ -100,7 +100,7 @@ function uploadFile(file, root, remixMetadata) {
   var path = root + file.get('path');
   var mimeType = mime.lookup(path);
 
-  if (mimeType === 'text/html') {
+  if (mimeType === 'text/html' && !remixMetadata.readonly) {
     buffer = new Buffer(Remix.inject(buffer.toString(), remixMetadata));
   }
 
@@ -188,7 +188,8 @@ exports.publish = function publish(project) {
         projectTitle: publishedProject.get('title'),
         projectAuthor: user.get('name'),
         dateUpdated: project.get('date_updated'),
-        host: Remix.resourceHost
+        host: Remix.resourceHost,
+        readonly: project.get('readonly')
       };
     });
   })


### PR DESCRIPTION
fixes https://github.com/mozilla/publish.webmaker.org/issues/173

builds on top of #171 for its schema extension/migration, the only new code on top of that PR here is https://github.com/Pomax/publish.webmaker.org/commit/149c4635f9f16f942abbd860e7a646634b27a70d (last commit in the series)

Turns off the injection of the "remix" script for `text/html` files if the project metadata contains the `readonly` flag (and it is set to `true`)