### PR TITLE
Update dates for existing published projects

### DIFF
--- a/migrations/6_update_dates_existing_published_projects.js
+++ b/migrations/6_update_dates_existing_published_projects.js
@@ -1,0 +1,45 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return knex('publishedProjects')
+  .whereNull('date_created')
+  .orWhereNull('date_updated')
+  .select('id', 'date_created', 'date_updated')
+  .then(function(publishedProjects) {
+    return Promise.map(publishedProjects, function(publishedProject) {
+      var publishedProjectId = publishedProject.id;
+      var dateUpdated = publishedProject.date_updated;
+
+      // For existing published projects that have been updated since
+      // date tracking has been added, they will have a date_updated
+      // but not a date_created. Set the date_created to the date_updated
+      if (dateUpdated) {
+        return knex('publishedProjects').update('date_created', dateUpdated)
+        .where('id', publishedProjectId);
+      }
+
+      // For existing published projects that have not been updated
+      // since date tracking has been added - set both the dates
+      // to the date_updated of the corresponding project
+      return knex('projects')
+      .where('published_id', publishedProjectId).select('date_updated')
+      .then(function(projects) {
+        var date = projects[0].date_updated;
+
+        // Update the date_created and date_updated fields in the
+        // publishedProjects table
+        return knex('publishedProjects')
+        .where('id', publishedProjectId)
+        .update({
+          date_created: date,
+          date_updated: date
+        });
+      });
+    });
+  });
+};
+
+exports.down = function (knex, Promise) {
+  // This is an "update once" migration so that we do not lose data
+  return Promise.resolve();
+};

--- a/seeds/4_publishedProjects.js
+++ b/seeds/4_publishedProjects.js
@@ -4,12 +4,24 @@ exports.seed = function(knex, Promise) {
       title: 'sinatra-contrib',
       tags: 'ruby, sinatra, community, utilities',
       description: 'Hydrogen atoms Sea of Tranquility are creatures of the cosmos shores of the cosmic ocean.',
-      date_created: '2015-06-03T16:21:58.000Z',
-      date_updated: '2015-06-03T16:41:58.000Z'
+      date_created: '2015-06-19T17:21:58.000Z',
+      date_updated: '2015-06-23T06:41:58.000Z'
     }),
-    knex('projects').where('id', 2)
-    .update({
-      published_id: 1
+    knex('publishedProjects').insert({
+      title: 'spacecats-API',
+      tags: 'sinatra, api, REST, server, ruby',
+      description: 'Venture a very small stage in a vast cosmic arena Euclid billions upon billions!'
     })
-  );
+  ).then(function() {
+    return Promise.join(
+      knex('projects').where('id', 2)
+      .update({
+        published_id: 1
+      }),
+      knex('projects').where('id', 1)
+      .update({
+        published_id: 2
+      })
+    );
+  });
 };

--- a/test/lib/fixtures/files/test-files.js
+++ b/test/lib/fixtures/files/test-files.js
@@ -13,7 +13,7 @@ module.exports = function(cb) {
     return cb(null, files);
   }
 
-  db.select().table('files')
+  db.select().table('files').orderBy('id')
     .then(function(rows) {
       files.valid = rows;
       cb(null, files);

--- a/test/lib/fixtures/projects/test-projects.js
+++ b/test/lib/fixtures/projects/test-projects.js
@@ -13,7 +13,7 @@ module.exports = function(cb) {
     return cb(null, projects);
   }
 
-  db.select().table('projects')
+  db.select().table('projects').orderBy('id')
     .then(function(rows) {
       projects.valid = rows;
       cb(null, projects);

--- a/test/lib/fixtures/publishedProjects/test-publishedProjects.js
+++ b/test/lib/fixtures/publishedProjects/test-publishedProjects.js
@@ -13,7 +13,7 @@ module.exports = function(callback) {
     return callback(null, publishedProjects);
   }
 
-  db.select().table('publishedProjects')
+  db.select().table('publishedProjects').orderBy('id')
   .then(function(rows) {
     publishedProjects.valid = rows;
     callback(null, publishedProjects);

--- a/test/lib/fixtures/users/test-users.js
+++ b/test/lib/fixtures/users/test-users.js
@@ -11,7 +11,7 @@ module.exports = function(cb) {
     return cb(null, users);
   }
 
-  db.select().from('users')
+  db.select().from('users').orderBy('id')
     .then(function(rows) {
       users.valid = rows;
       cb(null, users);


### PR DESCRIPTION
This patch does two things:

1. It fixes a seeding issue caused by the improper use of Promises which lead to an attempt to update the `projects` table with a `published_id` which references a published project in the `publishedProjects` table that hadn't been created yet.
2. Removes null values for the `date_created` and `date_updated` fields in the `publishedProjects` table caused by published projects that existed before the previous migration was landed. 
 * For those published projects that were re-published after the date tracking feature was added, they only miss a `date_created`. So, we set it to the `date_updated` value to assume that it was created for the first time when it was updated. 
 * For those published projects that were not re-published after the date tracking feature was added, they miss the `date_created` and `date_updated` fields. So, we set them to the `date_updated` for their corresponding project in the `projects` table.