### PR TITLE
Use datetime sql type to store project dates

### DIFF
--- a/api/classes/publisher.js
+++ b/api/classes/publisher.js
@@ -195,7 +195,7 @@ function createOrUpdatePublishedProject() {
     title: project.title,
     tags: project.tags,
     description: project.description,
-    date_updated: (new Date()).toISOString()
+    date_updated: new Date()
   };
 
   return fetchPublishedProject.call(self)

--- a/api/modules/projects/controller.js
+++ b/api/modules/projects/controller.js
@@ -36,14 +36,25 @@ controller.formatRequestData = function(req) {
     user_id: req.payload.user_id,
     tags: req.payload.tags,
     description: req.payload.description,
-    date_created: new Date(req.payload.date_created),
-    date_updated: new Date(req.payload.date_updated),
+    date_created: req.payload.date_created,
+    date_updated: req.payload.date_updated,
     readonly: req.payload.readonly,
     client: req.payload.client
   };
   if (req.params.id) {
     data.id = parseInt(req.params.id);
   }
+  return data;
+};
+
+controller.formatResponseData = function(data) {
+  if (isDate(data.date_created)) {
+    data.date_created = data.date_created.toISOString();
+  }
+  if (isDate(data.date_updated)) {
+    data.date_updated = data.date_updated.toISOString();
+  }
+
   return data;
 };
 

--- a/api/modules/projects/model.js
+++ b/api/modules/projects/model.js
@@ -12,12 +12,12 @@ var instanceProps = {
     return this.belongsTo(require('../publishedProjects/model'), 'published_id');
   },
   format: function(model) {
-    if(typeof model === "object") {
+    if (typeof model === 'object') {
       // Have to do this because of this bug: https://github.com/tgriesser/bookshelf/issues/668
-      if(model.date_created) {
+      if (model.date_created) {
         model._date_created = new Date(model.date_created);
       }
-      if(model.date_updated) {
+      if (model.date_updated) {
         model._date_updated = new Date(model.date_updated);
       }
     }
@@ -25,7 +25,7 @@ var instanceProps = {
     return model;
   },
   parse: function(model) {
-    if(typeof model === "object") {
+    if (typeof model === 'object') {
       delete model._date_created;
       delete model._date_updated;
     }

--- a/api/modules/projects/model.js
+++ b/api/modules/projects/model.js
@@ -16,18 +16,26 @@ var instanceProps = {
       // Have to do this because of this bug: https://github.com/tgriesser/bookshelf/issues/668
       if (model.date_created) {
         model._date_created = new Date(model.date_created);
+        delete model.date_created;
       }
       if (model.date_updated) {
         model._date_updated = new Date(model.date_updated);
+        delete model.date_updated;
       }
     }
 
     return model;
   },
   parse: function(model) {
-    if (typeof model === 'object') {
-      delete model._date_created;
-      delete model._date_updated;
+    if (typeof model === "object") {
+      if (model._date_created) {
+        model.date_created = model._date_created.toISOString();
+        delete model._date_created;
+      }
+      if (model._date_updated) {
+        model.date_updated = model._date_updated.toISOString();
+        delete model._date_updated;
+      }
     }
 
     return model;

--- a/api/modules/projects/model.js
+++ b/api/modules/projects/model.js
@@ -11,6 +11,27 @@ var instanceProps = {
   publishedProject: function() {
     return this.belongsTo(require('../publishedProjects/model'), 'published_id');
   },
+  format: function(model) {
+    if(typeof model === "object") {
+      // Have to do this because of this bug: https://github.com/tgriesser/bookshelf/issues/668
+      if(model.date_created) {
+        model._date_created = new Date(model.date_created);
+      }
+      if(model.date_updated) {
+        model._date_updated = new Date(model.date_updated);
+      }
+    }
+
+    return model;
+  },
+  parse: function(model) {
+    if(typeof model === "object") {
+      delete model._date_created;
+      delete model._date_updated;
+    }
+
+    return model;
+  },
   queries: function() {
     var self = this;
     var Project = this.constructor;

--- a/api/modules/projects/model.js
+++ b/api/modules/projects/model.js
@@ -15,11 +15,11 @@ var instanceProps = {
     if (typeof model === 'object') {
       // Have to do this because of this bug: https://github.com/tgriesser/bookshelf/issues/668
       if (model.date_created) {
-        model._date_created = new Date(model.date_created);
+        model._date_created = model.date_created;
         delete model.date_created;
       }
       if (model.date_updated) {
-        model._date_updated = new Date(model.date_updated);
+        model._date_updated = model.date_updated;
         delete model.date_updated;
       }
     }
@@ -27,13 +27,13 @@ var instanceProps = {
     return model;
   },
   parse: function(model) {
-    if (typeof model === "object") {
+    if (typeof model === 'object') {
       if (model._date_created) {
-        model.date_created = model._date_created.toISOString();
+        model.date_created = model._date_created;
         delete model._date_created;
       }
       if (model._date_updated) {
-        model.date_updated = model._date_updated.toISOString();
+        model.date_updated = model._date_updated;
         delete model._date_updated;
       }
     }
@@ -49,13 +49,13 @@ var instanceProps = {
         return new Project().query()
         .where(self.column('id'), id)
         .then(function(projects) {
-          return projects[0];
+          return self.parse(projects[0]);
         });
       },
       updateOne: function(id, updatedValues) {
         return new Project().query()
         .where(self.column('id'), id)
-        .update(updatedValues)
+        .update(self.format(updatedValues))
         .then(function() {
           return id;
         });

--- a/api/modules/projects/schema.js
+++ b/api/modules/projects/schema.js
@@ -3,8 +3,8 @@ var Joi = require('joi');
 module.exports = Joi.object().keys({
   title: Joi.string().required(),
   user_id: Joi.number().integer().required(),
-  date_created: Joi.string().required(),
-  date_updated: Joi.string().required(),
+  date_created: Joi.date().required(),
+  date_updated: Joi.date().required(),
   description: Joi.string().allow('').allow(null),
   tags: Joi.string().allow(null),
   published_id: Joi.number().allow(null),

--- a/api/modules/publishedProjects/controller.js
+++ b/api/modules/publishedProjects/controller.js
@@ -34,6 +34,17 @@ function formatResponse(model) {
   return model;
 }
 
+controller.formatResponseData = function(data) {
+  if (isDate(data.date_created)) {
+    data.date_created = data.date_created.toISOString();
+  }
+  if (isDate(data.date_updated)) {
+    data.date_updated = data.date_updated.toISOString();
+  }
+
+  return data;
+};
+
 controller.create = function(req, reply) {
   return BaseController.prototype.create.call(this, req, reply, formatResponse);
 };

--- a/api/modules/publishedProjects/controller.js
+++ b/api/modules/publishedProjects/controller.js
@@ -15,6 +15,33 @@ function ensureRemixSuffix(title) {
   return title.replace(/( \(remix\))*$/, ' (remix)');
 }
 
+// Taken from http://stackoverflow.com/a/643827
+function isDate(val) {
+  return Object.prototype.toString.call(val) === '[object Date]';
+}
+
+function formatResponse(model) {
+  var created = model.get('date_created');
+  var updated = model.get('date_updated');
+
+  if (isDate(created)) {
+    model.set('date_created', created.toISOString());
+  }
+  if (isDate(updated)) {
+    model.set('date_updated', updated.toISOString());
+  }
+
+  return model;
+}
+
+controller.create = function(req, reply) {
+  return BaseController.prototype.create.call(this, req, reply, formatResponse);
+};
+
+controller.update = function(req, reply) {
+  return BaseController.prototype.update.call(this, req, reply, formatResponse);
+};
+
 controller.remix = function(req, reply) {
   var publishedProject = req.pre.records.models[0];
   var user = req.pre.user;
@@ -55,6 +82,7 @@ controller.remix = function(req, reply) {
       date_updated: req.query.now
     }).save()
     .then(copyFiles)
+    .then(formatResponse)
     .catch(errors.generateErrorResponse);
   }
 

--- a/api/modules/publishedProjects/model.js
+++ b/api/modules/publishedProjects/model.js
@@ -14,11 +14,11 @@ var instanceProps = {
     return this.hasMany(require('../publishedFiles/model'));
   },
   format: function(model) {
-    if(typeof model === "object") {
-      if(model.date_created) {
+    if (typeof model === 'object') {
+      if (model.date_created) {
         model._date_created = new Date(model.date_created);
       }
-      if(model.date_updated) {
+      if (model.date_updated) {
         model._date_updated = new Date(model.date_updated);
       }
     }
@@ -26,7 +26,7 @@ var instanceProps = {
     return model;
   },
   parse: function(model) {
-    if(typeof model === "object") {
+    if (typeof model === 'object') {
       delete model._date_created;
       delete model._date_updated;
     }

--- a/api/modules/publishedProjects/model.js
+++ b/api/modules/publishedProjects/model.js
@@ -13,6 +13,26 @@ var instanceProps = {
   publishedFiles: function() {
     return this.hasMany(require('../publishedFiles/model'));
   },
+  format: function(model) {
+    if(typeof model === "object") {
+      if(model.date_created) {
+        model._date_created = new Date(model.date_created);
+      }
+      if(model.date_updated) {
+        model._date_updated = new Date(model.date_updated);
+      }
+    }
+
+    return model;
+  },
+  parse: function(model) {
+    if(typeof model === "object") {
+      delete model._date_created;
+      delete model._date_updated;
+    }
+
+    return model;
+  },
   queries: function() {
     var self = this;
     var PublishedProject = this.constructor;

--- a/api/modules/publishedProjects/model.js
+++ b/api/modules/publishedProjects/model.js
@@ -16,11 +16,11 @@ var instanceProps = {
   format: function(model) {
     if (typeof model === 'object') {
       if (model.date_created) {
-        model._date_created = new Date(model.date_created);
+        model._date_created = model.date_created;
         delete model.date_created;
       }
       if (model.date_updated) {
-        model._date_updated = new Date(model.date_updated);
+        model._date_updated = model.date_updated;
         delete model.date_updated;
       }
     }
@@ -28,13 +28,13 @@ var instanceProps = {
     return model;
   },
   parse: function(model) {
-    if (typeof model === "object") {
+    if (typeof model === 'object') {
       if (model._date_created) {
-        model.date_created = model._date_created.toISOString();
+        model.date_created = model._date_created;
         delete model._date_created;
       }
       if (model._date_updated) {
-        model.date_updated = model._date_updated.toISOString();
+        model.date_updated = model._date_updated;
         delete model._date_updated;
       }
     }
@@ -50,12 +50,12 @@ var instanceProps = {
         return new PublishedProject().query()
         .where(self.column('id'), id)
         .then(function(publishedProjects) {
-          return publishedProjects[0];
+          return self.parse(publishedProjects[0]);
         });
       },
       createOne: function(data) {
         return new PublishedProject().query()
-        .insert(data, 'id')
+        .insert(self.format(data), 'id')
         .then(function(ids) {
           return ids[0];
         });
@@ -63,7 +63,7 @@ var instanceProps = {
       updateOne: function(id, updatedValues) {
         return new PublishedProject().query()
         .where(self.column('id'), id)
-        .update(updatedValues)
+        .update(self.format(updatedValues))
         .then(function() {
           return id;
         });

--- a/api/modules/publishedProjects/model.js
+++ b/api/modules/publishedProjects/model.js
@@ -17,18 +17,26 @@ var instanceProps = {
     if (typeof model === 'object') {
       if (model.date_created) {
         model._date_created = new Date(model.date_created);
+        delete model.date_created;
       }
       if (model.date_updated) {
         model._date_updated = new Date(model.date_updated);
+        delete model.date_updated;
       }
     }
 
     return model;
   },
   parse: function(model) {
-    if (typeof model === 'object') {
-      delete model._date_created;
-      delete model._date_updated;
+    if (typeof model === "object") {
+      if (model._date_created) {
+        model.date_created = model._date_created.toISOString();
+        delete model._date_created;
+      }
+      if (model._date_updated) {
+        model.date_updated = model._date_updated.toISOString();
+        delete model._date_updated;
+      }
     }
 
     return model;

--- a/api/modules/publishedProjects/schema.js
+++ b/api/modules/publishedProjects/schema.js
@@ -1,5 +1,5 @@
 var Joi = require('joi');
 
 module.exports = Joi.object().keys({
-  now: Joi.string().required()
+  now: Joi.date().required()
 });

--- a/migrations/20151117173053_add_datetime_columns.js
+++ b/migrations/20151117173053_add_datetime_columns.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return Promise.join(
+    knex.schema.table('projects', function(t) {
+      t.dateTime('_date_created');
+      t.dateTime('_date_updated');
+    }),
+    knex.schema.table('publishedProjects', function(t) {
+      t.dateTime('_date_created');
+      t.dateTime('_date_updated');
+    })
+  );
+};
+
+exports.down = function (knex, Promise) {
+  // Irreversible, as this can lead to permanent data loss.
+  return Promise.resolve();
+};

--- a/migrations/20151120164525_copy_text_date_columns_into_datetime_columns.js
+++ b/migrations/20151120164525_copy_text_date_columns_into_datetime_columns.js
@@ -1,0 +1,79 @@
+'use strict';
+
+function getDateFromStr(dateStr, id, table, column) {
+  var date;
+
+  if (!dateStr) {
+    return null;
+  }
+
+  try {
+    date = new Date(dateStr);
+    if (isNaN(date.valueOf())) {
+      throw new Error('Date string is not valid');
+    }
+  } catch (e) {
+    console.error('Record with `id` ' + id + ' ' +
+                  'has an invalid entry for `' + column + '` ' +
+                  'with value ' + dateStr + ' ' +
+                  'in table `' + table + '`');
+  } finally {
+    return date;
+  }
+}
+
+function getDatesFromRecord(record, table) {
+  var id = record.id;
+  var created = getDateFromStr(record.date_created, id, table, 'date_created');
+  var updated = getDateFromStr(record.date_updated, id, table, 'date_updated');
+
+  if (!created && updated) {
+    created = updated;
+  }
+
+  if (created && !updated) {
+    updated = created;
+  }
+
+  if (!created && !updated) {
+    created = updated = getDateFromStr();
+  }
+
+  return {
+    created: created,
+    updated: updated
+  };
+}
+
+function copyDates(knex, Promise, table) {
+  return knex(table)
+  .select('id', 'date_created', 'date_updated')
+  .then(function(records) {
+    return Promise.map(records, function(record) {
+      var id = record.id;
+      var dates = getDatesFromRecord(record, table);
+
+      return Promise.join(
+        knex(table).update('_date_created', dates.created)
+        .where('id', id)
+        .whereNull('_date_created'),
+
+        knex(table).update('_date_updated', dates.updated)
+        .where('id', id)
+        .whereNull('_date_updated')
+      );
+    });
+  });
+}
+
+exports.up = function(knex, Promise) {
+  return Promise.join(
+    copyDates(knex, Promise, 'projects'),
+    copyDates(knex, Promise, 'publishedProjects')
+  );
+};
+
+exports.down = function (knex, Promise) {
+  // Irreversible, as this can lead to permanent data loss.
+  return Promise.resolve();
+};

--- a/migrations/20151202115135_make_text_date_columns_nullable.js
+++ b/migrations/20151202115135_make_text_date_columns_nullable.js
@@ -1,0 +1,16 @@
+'use strict';
+
+exports.up = function(knex, Promise) {
+  return Promise.join(
+    knex.raw('ALTER TABLE projects ALTER date_created DROP NOT NULL'),
+    knex.raw('ALTER TABLE projects ALTER date_updated DROP NOT NULL'),
+
+    knex.raw('ALTER TABLE \"publishedProjects\" ALTER date_created DROP NOT NULL'),
+    knex.raw('ALTER TABLE \"publishedProjects\" ALTER date_updated DROP NOT NULL')
+  );
+};
+
+exports.down = function (knex, Promise) {
+  // Irreversible, as this can lead to permanent data loss.
+  return Promise.resolve();
+};

--- a/migrations/20151202120458_delete_text_date_columns.js
+++ b/migrations/20151202120458_delete_text_date_columns.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = function(knex, Promise) {
+  return Promise.join(
+    knex.schema.table('projects', function(t) {
+      t.dropColumn('date_created');
+      t.dropColumn('date_updated');
+    }),
+    knex.schema.table('publishedProjects', function(t) {
+      t.dropColumn('date_created');
+      t.dropColumn('date_updated');
+    })
+  );
+};
+
+exports.down = function(knex, Promise) {
+  // Irreversible, you cannot re-create the column with the original data
+  return Promise.resolve();
+};

--- a/seeds/2_projects.js
+++ b/seeds/2_projects.js
@@ -7,16 +7,16 @@ exports.seed = function(knex, Promise) {
       title: 'spacecats-API',
       tags: 'sinatra, api, REST, server, ruby',
       description: 'Venture a very small stage in a vast cosmic arena Euclid billions upon billions!',
-      date_created: '2015-06-03T13:21:58+00:00',
-      date_updated: '2015-06-03T13:21:58+00:00'
+      _date_created: new Date('2015-06-03T13:21:58+00:00'),
+      _date_updated: new Date('2015-06-03T13:21:58+00:00')
     }),
     knex('projects').insert({
       user_id: 1,
       title: 'sinatra-contrib',
       tags: 'ruby, sinatra, community, utilities',
       description: 'Hydrogen atoms Sea of Tranquility are creatures of the cosmos shores of the cosmic ocean.',
-      date_created: '2015-06-03T13:21:58+00:00',
-      date_updated: '2015-06-03T13:21:58+00:00',
+      _date_created: new Date('2015-06-03T13:21:58+00:00'),
+      _date_updated: new Date('2015-06-03T13:21:58+00:00'),
       readonly: true
     }),
     knex('projects').insert({
@@ -25,8 +25,8 @@ exports.seed = function(knex, Promise) {
       tags: 'android, mobile, social',
       description: 'Gathered by gravity encyclopaedia galactica permanence of ' +
         'the stars made in the interiors of collapsing stars! ',
-      date_created: '2015-06-03T13:21:58+00:00',
-      date_updated: '2015-06-03T13:21:58+00:00',
+      _date_created: new Date('2015-06-03T13:21:58+00:00'),
+      _date_updated: new Date('2015-06-03T13:21:58+00:00'),
       client: 'webmaker-android'
     }),
     knex('projects').insert({
@@ -35,8 +35,8 @@ exports.seed = function(knex, Promise) {
       tags: 'web',
       description: 'Orions sword a still more glorious dawn awaits at the edge ' +
         'of forever consciousness, cosmic fugue Vangelis, globular star cluster.',
-      date_created: '2015-06-03T13:21:58+00:00',
-      date_updated: '2015-06-03T13:21:58+00:00',
+      _date_created: new Date('2015-06-03T13:21:58+00:00'),
+      _date_updated: new Date('2015-06-03T13:21:58+00:00'),
       readonly: true,
       client: 'makedrive'
     })

--- a/seeds/4_publishedProjects.js
+++ b/seeds/4_publishedProjects.js
@@ -4,8 +4,8 @@ exports.seed = function(knex, Promise) {
       title: 'sinatra-contrib',
       tags: 'ruby, sinatra, community, utilities',
       description: 'Hydrogen atoms Sea of Tranquility are creatures of the cosmos shores of the cosmic ocean.',
-      date_created: '2015-06-19T17:21:58.000Z',
-      date_updated: '2015-06-23T06:41:58.000Z'
+      _date_created: new Date('2015-06-19T17:21:58.000Z'),
+      _date_updated: new Date('2015-06-23T06:41:58.000Z')
     }),
     knex('publishedProjects').insert({
       title: 'spacecats-API',

--- a/test/lib/fixtures/projects/create.js
+++ b/test/lib/fixtures/projects/create.js
@@ -92,7 +92,7 @@ module.exports = function(cb) {
         payload: {
           title: 'Test project',
           user_id: validUsers[0].id,
-          date_created: 123,
+          date_created: 'This is an invalid date',
           date_updated: '01/01/15',
           description: 'A test project',
           tags: 'test, project, foo, whiz',
@@ -108,7 +108,7 @@ module.exports = function(cb) {
           title: 'Test project',
           user_id: validUsers[0].id,
           date_created: '01/01/15',
-          date_updated: 123,
+          date_updated: 'This is an invalid date',
           description: 'A test project',
           tags: 'test, project, foo, whiz',
           readonly: false,

--- a/test/lib/fixtures/projects/test-projects.js
+++ b/test/lib/fixtures/projects/test-projects.js
@@ -15,6 +15,16 @@ module.exports = function(cb) {
 
   db.select().table('projects').orderBy('id')
     .then(function(rows) {
+      rows.forEach(function(row) {
+        if (row._date_created) {
+          row.date_created = row._date_created.toISOString();
+          delete row._date_created;
+        }
+        if (row._date_updated) {
+          row.date_updated = row._date_updated.toISOString();
+          delete row._date_updated;
+        }
+      });
       projects.valid = rows;
       cb(null, projects);
     })

--- a/test/lib/fixtures/publishedProjects/test-publishedProjects.js
+++ b/test/lib/fixtures/publishedProjects/test-publishedProjects.js
@@ -15,6 +15,16 @@ module.exports = function(callback) {
 
   db.select().table('publishedProjects').orderBy('id')
   .then(function(rows) {
+    rows.forEach(function(row) {
+      if (row._date_created) {
+        row.date_created = row._date_created.toISOString();
+        delete row._date_created;
+      }
+      if (row._date_updated) {
+        row.date_updated = row._date_updated.toISOString();
+        delete row._date_updated;
+      }
+    });
     publishedProjects.valid = rows;
     callback(null, publishedProjects);
   })


### PR DESCRIPTION
This builds on https://github.com/mozilla/publish.webmaker.org/pull/192 and relies on it landing first.

This PR changes the existing date columns stored as text in the `projects` and `publishedProjects` tables to use the datetime sql type instead.