### PR TITLE
Issue165

### DIFF
--- a/api/classes/publisher.js
+++ b/api/classes/publisher.js
@@ -195,7 +195,7 @@ function createOrUpdatePublishedProject() {
     title: project.title,
     tags: project.tags,
     description: project.description,
-    date_updated: new Date()
+    date_updated: (new Date()).toISOString()
   };
 
   return fetchPublishedProject.call(self)

--- a/api/classes/publisher.js
+++ b/api/classes/publisher.js
@@ -182,7 +182,7 @@ function setRemixDataForPublishedProject() {
     projectId: self.publishedProject.id,
     projectTitle: self.publishedProject.title,
     projectAuthor: self.user.name,
-    dateUpdated: self.project.date_updated,
+    dateUpdated: self.publishedProject.date_updated.toISOString(),
     host: Remix.resourceHost,
     readonly: self.project.readonly
   };

--- a/api/modules/projects/controller.js
+++ b/api/modules/projects/controller.js
@@ -31,19 +31,24 @@ function formatResponse(model) {
 }
 
 controller.formatRequestData = function(req) {
+  var now = new Date();
   var data = {
     title: req.payload.title,
     user_id: req.payload.user_id,
     tags: req.payload.tags,
     description: req.payload.description,
-    date_created: req.payload.date_created,
-    date_updated: req.payload.date_updated,
+    date_created: now,
+    date_updated: now,
     readonly: req.payload.readonly,
     client: req.payload.client
   };
+
+  // If it is an update request
   if (req.params.id) {
     data.id = parseInt(req.params.id);
+    delete data.date_created;
   }
+
   return data;
 };
 

--- a/api/modules/projects/controller.js
+++ b/api/modules/projects/controller.js
@@ -11,24 +11,7 @@ var PublishedFiles = require('../publishedFiles/model');
 var Model = require('./model');
 var controller = new BaseController(Model);
 
-// Taken from http://stackoverflow.com/a/643827
-function isDate(val) {
-  return Object.prototype.toString.call(val) === '[object Date]';
-}
-
-function formatResponse(model) {
-  var created = model.get('date_created');
-  var updated = model.get('date_updated');
-
-  if (isDate(created)) {
-    model.set('date_created', created.toISOString());
-  }
-  if (isDate(updated)) {
-    model.set('date_updated', updated.toISOString());
-  }
-
-  return model;
-}
+var dateTracker = require('../../../lib/utils').dateTracker;
 
 controller.formatRequestData = function(req) {
   var now = new Date();
@@ -52,23 +35,14 @@ controller.formatRequestData = function(req) {
   return data;
 };
 
-controller.formatResponseData = function(data) {
-  if (isDate(data.date_created)) {
-    data.date_created = data.date_created.toISOString();
-  }
-  if (isDate(data.date_updated)) {
-    data.date_updated = data.date_updated.toISOString();
-  }
-
-  return data;
-};
+controller.formatResponseData = dateTracker.convertToISOStrings();
 
 controller.create = function(req, reply) {
-  return BaseController.prototype.create.call(this, req, reply, formatResponse);
+  return BaseController.prototype.create.call(this, req, reply, dateTracker.convertToISOStrings(true));
 };
 
 controller.update = function(req, reply) {
-  return BaseController.prototype.update.call(this, req, reply, formatResponse);
+  return BaseController.prototype.update.call(this, req, reply, dateTracker.convertToISOStrings(true));
 };
 
 controller.publishProject = function(req, reply) {
@@ -76,7 +50,7 @@ controller.publishProject = function(req, reply) {
     var record = req.pre.records.models[0];
 
     return Publisher.publish(record)
-    .then(formatResponse)
+    .then(dateTracker.convertToISOStrings(true))
     .then(function(publishedRecord) {
       return req.generateResponse(publishedRecord).code(200);
     });
@@ -98,7 +72,7 @@ controller.unpublishProject = function(req, reply) {
     }
 
     return Publisher.unpublish(record)
-    .then(formatResponse)
+    .then(dateTracker.convertToISOStrings(true))
     .then(function(unpublishedRecord) {
       return req.generateResponse(unpublishedRecord).code(200);
     });

--- a/api/modules/projects/model.js
+++ b/api/modules/projects/model.js
@@ -1,5 +1,7 @@
 var BaseModel = require('../../classes/base_model');
 
+var dateTracker = require('../../../lib/utils').dateTracker;
+
 var instanceProps = {
   tableName: 'projects',
   user: function () {
@@ -11,35 +13,8 @@ var instanceProps = {
   publishedProject: function() {
     return this.belongsTo(require('../publishedProjects/model'), 'published_id');
   },
-  format: function(model) {
-    if (typeof model === 'object') {
-      // Have to do this because of this bug: https://github.com/tgriesser/bookshelf/issues/668
-      if (model.date_created) {
-        model._date_created = model.date_created;
-        delete model.date_created;
-      }
-      if (model.date_updated) {
-        model._date_updated = model.date_updated;
-        delete model.date_updated;
-      }
-    }
-
-    return model;
-  },
-  parse: function(model) {
-    if (typeof model === 'object') {
-      if (typeof model._date_created !== 'undefined') {
-        model.date_created = model._date_created;
-        delete model._date_created;
-      }
-      if (typeof model._date_updated !== 'undefined') {
-        model.date_updated = model._date_updated;
-        delete model._date_updated;
-      }
-    }
-
-    return model;
-  },
+  format: dateTracker.formatDatesInModel.bind(this),
+  parse: dateTracker.parseDatesInModel.bind(this),
   queries: function() {
     var self = this;
     var Project = this.constructor;

--- a/api/modules/projects/schema.js
+++ b/api/modules/projects/schema.js
@@ -3,8 +3,8 @@ var Joi = require('joi');
 module.exports = Joi.object().keys({
   title: Joi.string().required(),
   user_id: Joi.number().integer().required(),
-  date_created: Joi.date().required(),
-  date_updated: Joi.date().required(),
+  date_created: Joi.date(),
+  date_updated: Joi.date(),
   description: Joi.string().allow('').allow(null),
   tags: Joi.string().allow(null),
   published_id: Joi.number().allow(null),

--- a/api/modules/publishedProjects/controller.js
+++ b/api/modules/publishedProjects/controller.js
@@ -84,13 +84,15 @@ controller.remix = function(req, reply) {
   }
 
   function duplicateProject() {
+    var now = new Date();
+
     return Projects.forge({
       title: ensureRemixSuffix(publishedProject.get('title')),
       user_id: user.get('id'),
       tags: publishedProject.get('tags'),
       description: publishedProject.description,
-      date_created: req.query.now,
-      date_updated: req.query.now
+      date_created: now,
+      date_updated: now
     }).save()
     .then(copyFiles)
     .then(formatResponse)

--- a/api/modules/publishedProjects/controller.js
+++ b/api/modules/publishedProjects/controller.js
@@ -9,48 +9,22 @@ var Projects = require('../projects/model');
 var Files = require('../files/model');
 var PublishedFiles = require('../publishedFiles/model');
 
+var dateTracker = require('../../../lib/utils').dateTracker;
+
 // Make sure we have the ' (remix)' suffix, adding if necessary,
 // but not re-adding to a title that already has it (remix of remix).
 function ensureRemixSuffix(title) {
   return title.replace(/( \(remix\))*$/, ' (remix)');
 }
 
-// Taken from http://stackoverflow.com/a/643827
-function isDate(val) {
-  return Object.prototype.toString.call(val) === '[object Date]';
-}
-
-function formatResponse(model) {
-  var created = model.get('date_created');
-  var updated = model.get('date_updated');
-
-  if (isDate(created)) {
-    model.set('date_created', created.toISOString());
-  }
-  if (isDate(updated)) {
-    model.set('date_updated', updated.toISOString());
-  }
-
-  return model;
-}
-
-controller.formatResponseData = function(data) {
-  if (isDate(data.date_created)) {
-    data.date_created = data.date_created.toISOString();
-  }
-  if (isDate(data.date_updated)) {
-    data.date_updated = data.date_updated.toISOString();
-  }
-
-  return data;
-};
+controller.formatResponseData = dateTracker.convertToISOStrings();
 
 controller.create = function(req, reply) {
-  return BaseController.prototype.create.call(this, req, reply, formatResponse);
+  return BaseController.prototype.create.call(this, req, reply, dateTracker.convertToISOStrings(true));
 };
 
 controller.update = function(req, reply) {
-  return BaseController.prototype.update.call(this, req, reply, formatResponse);
+  return BaseController.prototype.update.call(this, req, reply, dateTracker.convertToISOStrings(true));
 };
 
 controller.remix = function(req, reply) {
@@ -84,7 +58,7 @@ controller.remix = function(req, reply) {
   }
 
   function duplicateProject() {
-    var now = new Date();
+    var now = (new Date()).toISOString();
 
     return Projects.forge({
       title: ensureRemixSuffix(publishedProject.get('title')),
@@ -95,7 +69,7 @@ controller.remix = function(req, reply) {
       date_updated: now
     }).save()
     .then(copyFiles)
-    .then(formatResponse)
+    .then(dateTracker.convertToISOStrings(true))
     .catch(errors.generateErrorResponse);
   }
 

--- a/api/modules/publishedProjects/model.js
+++ b/api/modules/publishedProjects/model.js
@@ -2,6 +2,8 @@ var BaseModel = require('../../classes/base_model');
 
 var Projects = require('../projects/model');
 
+var dateTracker = require('../../../lib/utils').dateTracker;
+
 var instanceProps = {
   tableName: 'publishedProjects',
   project: function() {
@@ -13,34 +15,8 @@ var instanceProps = {
   publishedFiles: function() {
     return this.hasMany(require('../publishedFiles/model'));
   },
-  format: function(model) {
-    if (typeof model === 'object') {
-      if (model.date_created) {
-        model._date_created = model.date_created;
-        delete model.date_created;
-      }
-      if (model.date_updated) {
-        model._date_updated = model.date_updated;
-        delete model.date_updated;
-      }
-    }
-
-    return model;
-  },
-  parse: function(model) {
-    if (typeof model === 'object') {
-      if (typeof model._date_created !== 'undefined') {
-        model.date_created = model._date_created;
-        delete model._date_created;
-      }
-      if (typeof model._date_updated !== 'undefined') {
-        model.date_updated = model._date_updated;
-        delete model._date_updated;
-      }
-    }
-
-    return model;
-  },
+  format: dateTracker.formatDatesInModel.bind(this),
+  parse: dateTracker.parseDatesInModel.bind(this),
   queries: function() {
     var self = this;
     var PublishedProject = this.constructor;

--- a/api/modules/publishedProjects/routes/remix.js
+++ b/api/modules/publishedProjects/routes/remix.js
@@ -1,7 +1,5 @@
 var prereqs = require('../../../classes/prerequisites');
-var errors = require('../../../classes/errors');
 
-var schema = require('../schema');
 var controller = require('../controller');
 var model = require('../model');
 
@@ -17,10 +15,6 @@ module.exports = [{
       prereqs.validateUser()
     ],
     handler: controller.remix.bind(controller),
-    description: 'Create a new project object.',
-    validate: {
-      query: schema,
-      failAction: errors.attrs
-    }
+    description: 'Create a new project object.'
   }
 }];

--- a/api/modules/publishedProjects/schema.js
+++ b/api/modules/publishedProjects/schema.js
@@ -1,5 +1,0 @@
-var Joi = require('joi');
-
-module.exports = Joi.object().keys({
-  now: Joi.date().required()
-});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,67 @@
+// General purpose utility functions
+
+function isDate(val) {
+  return val instanceof Date;
+}
+
+var dateTracker = {
+  isDate: isDate,
+  formatDatesInModel: function(model) {
+    if (typeof model === 'object') {
+      // Have to do this because of this bug: https://github.com/tgriesser/bookshelf/issues/668
+      if (model.date_created) {
+        model._date_created = model.date_created;
+        delete model.date_created;
+      }
+      if (model.date_updated) {
+        model._date_updated = model.date_updated;
+        delete model.date_updated;
+      }
+    }
+
+    return model;
+  },
+  parseDatesInModel: function(model) {
+    if (typeof model === 'object') {
+      if (typeof model._date_created !== 'undefined') {
+        model.date_created = model._date_created;
+        delete model._date_created;
+      }
+      if (typeof model._date_updated !== 'undefined') {
+        model.date_updated = model._date_updated;
+        delete model._date_updated;
+      }
+    }
+
+    return model;
+  },
+  // `isModel` indicates whether the data passed in is a Bookshelf model or not
+  convertToISOStrings: function(isModel) {
+    return function(data) {
+      var created = isModel ? data.get('date_created') : data.date_created;
+      var updated = isModel ? data.get('date_updated') : data.date_updated;
+
+      if (isDate(created)) {
+        if (isModel) {
+          data.set('date_created', created.toISOString());
+        } else {
+          data.date_created = created.toISOString();
+        }
+      }
+
+      if (isDate(updated)) {
+        if (isModel) {
+          data.set('date_updated', updated.toISOString());
+        } else {
+          data.date_updated = updated.toISOString();
+        }
+      }
+
+      return data;
+    };
+  }
+};
+
+module.exports = {
+  dateTracker: dateTracker
+};

--- a/seeds/2_projects.js
+++ b/seeds/2_projects.js
@@ -7,16 +7,16 @@ exports.seed = function(knex, Promise) {
       title: 'spacecats-API',
       tags: 'sinatra, api, REST, server, ruby',
       description: 'Venture a very small stage in a vast cosmic arena Euclid billions upon billions!',
-      _date_created: new Date('2015-06-03T13:21:58+00:00'),
-      _date_updated: new Date('2015-06-03T13:21:58+00:00')
+      _date_created: new Date('2015-06-03T13:21:58.000Z'),
+      _date_updated: new Date('2015-06-03T13:21:58.000Z')
     }),
     knex('projects').insert({
       user_id: 1,
       title: 'sinatra-contrib',
       tags: 'ruby, sinatra, community, utilities',
       description: 'Hydrogen atoms Sea of Tranquility are creatures of the cosmos shores of the cosmic ocean.',
-      _date_created: new Date('2015-06-03T13:21:58+00:00'),
-      _date_updated: new Date('2015-06-03T13:21:58+00:00'),
+      _date_created: new Date('2015-06-03T13:21:58.000Z'),
+      _date_updated: new Date('2015-06-03T13:21:58.000Z'),
       readonly: true
     }),
     knex('projects').insert({
@@ -25,8 +25,8 @@ exports.seed = function(knex, Promise) {
       tags: 'android, mobile, social',
       description: 'Gathered by gravity encyclopaedia galactica permanence of ' +
         'the stars made in the interiors of collapsing stars! ',
-      _date_created: new Date('2015-06-03T13:21:58+00:00'),
-      _date_updated: new Date('2015-06-03T13:21:58+00:00'),
+      _date_created: new Date('2015-06-03T13:21:58.000Z'),
+      _date_updated: new Date('2015-06-03T13:21:58.000Z'),
       client: 'webmaker-android'
     }),
     knex('projects').insert({
@@ -35,8 +35,8 @@ exports.seed = function(knex, Promise) {
       tags: 'web',
       description: 'Orions sword a still more glorious dawn awaits at the edge ' +
         'of forever consciousness, cosmic fugue Vangelis, globular star cluster.',
-      _date_created: new Date('2015-06-03T13:21:58+00:00'),
-      _date_updated: new Date('2015-06-03T13:21:58+00:00'),
+      _date_created: new Date('2015-06-03T13:21:58.000Z'),
+      _date_updated: new Date('2015-06-03T13:21:58.000Z'),
       readonly: true,
       client: 'makedrive'
     })


### PR DESCRIPTION
The values for `date_created` and `date_updated` for `projects` as well as `publishedProjects` will now be generated on the server and do not need to be passed in by the client. 
This is also true for the `/remix` route which took the date in the query string. 
(Dates will still be accepted in the request payload so that existing services that depend on publish do not break, but they will not be used).