### PR TITLE
added HTTP namespacing for whitelisted clients

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -12,6 +12,9 @@ export DATABASE_URL=postgres:///publish
 export API_HOST=0.0.0.0
 export PORT=2015
 
+# comma-separated list of clients that may publish to http://
+export HTTP_CLIENTS="X-Ray Goggles"
+
 # S3 publish/unpublish
 # (enter your own info plz)
 export AWS_ACCESS_KEY_ID=""

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "jscs": "^1.13.1",
     "jshint": "^2.8.0",
     "lab": "^5.9.0",
-    "mofo-style": "latest"
+    "mofo-style": "^1.0.0"
   }
 }


### PR DESCRIPTION
fixes https://github.com/mozilla/publish.webmaker.org/issues/224 by updating `buildURL` and `getUploadRoot` with a `client` argument, so we can adaptively set the upload root with or without an `/HTTP/` prefix depending on whether the client matches a whitelist for http publication.