### PR TITLE
Fix regression in ES6 re-write that replaces delete with set to undefined

### DIFF
--- a/api/classes/publisher.js
+++ b/api/classes/publisher.js
@@ -305,7 +305,7 @@ class BasePublisher {
       return Promise.map(publishedFiles, function(publishedFile) {
         const oldPath = publishedFile.oldPath;
 
-        publishedFile.oldPath = undefined;
+        delete publishedFile.oldPath;
 
         if (oldPath === publishedFile.path) {
           return updateModelAndUpload(publishedFile);


### PR DESCRIPTION
We can't just set to `undefined` because Bookshelf uses `hasOwnProperty` to check if a property exists or not.