### PR TITLE
Folder renames in projects are a separate operation now

### DIFF
--- a/api/modules/projects/routes.js
+++ b/api/modules/projects/routes.js
@@ -5,8 +5,9 @@ const read = require(`./routes/read.js`);
 const update = require(`./routes/update.js`);
 const del = require(`./routes/delete.js`);
 const publish = require(`./routes/publish`);
+const updatePaths = require(`./routes/update-paths`);
 
-const routes = [].concat(create, read, update, del, publish);
+const routes = [].concat(create, read, update, del, publish, updatePaths);
 
 exports.register = function(server, options, next) {
   server.route(routes);

--- a/api/modules/projects/routes/create.js
+++ b/api/modules/projects/routes/create.js
@@ -3,7 +3,7 @@
 const Prerequisites = require(`../../../classes/prerequisites`);
 const Errors = require(`../../../classes/errors`);
 
-const schema = require(`../schema`);
+const schema = require(`../schema`).base;
 const projectsController = require(`../controller`);
 
 module.exports = [{

--- a/api/modules/projects/routes/update-paths.js
+++ b/api/modules/projects/routes/update-paths.js
@@ -6,12 +6,19 @@ const Prerequisites = require(`../../../classes/prerequisites`);
 const Errors = require(`../../../classes/errors`);
 
 const ProjectsModel = require(`../model`);
-const schema = require(`../schema`).base;
+const schema = require(`../schema`).updatePaths;
 const projectsController = require(`../controller`);
 
+// RPC route to update file paths for a project usually due to a folder rename
+// The payload is expected to look something like:
+// {
+//   "/old/path/to/file1": "/new/path/to/file1",
+//   "/old/path/to/file2": "/new/path/to/file2",
+//   ...
+// }
 module.exports = [{
   method: `PUT`,
-  path: `/projects/{id}`,
+  path: `/projects/{id}/updatepaths`,
   config: {
     pre: [
       Prerequisites.confirmRecordExists(ProjectsModel, {
@@ -21,8 +28,10 @@ module.exports = [{
       Prerequisites.validateUser(),
       Prerequisites.validateOwnership()
     ],
-    handler: projectsController.update.bind(projectsController),
-    description: `Update a single project object based on \`id\`.`,
+    handler: projectsController.updatePaths.bind(projectsController),
+    description: `Update all file paths belonging to a project whose \`id\` ` +
+      `is specified and change those files paths to the ones specified ` +
+      `in the payload`,
     validate: {
       payload: schema,
       params: {

--- a/api/modules/projects/schema.js
+++ b/api/modules/projects/schema.js
@@ -2,7 +2,7 @@
 
 const Joi = require(`joi`);
 
-module.exports = Joi.object().keys({
+const base = Joi.object().keys({
   title: Joi.string().required(),
   user_id: Joi.number().integer().required(),
   date_created: Joi.date(),
@@ -13,3 +13,10 @@ module.exports = Joi.object().keys({
   readonly: Joi.boolean().allow(null),
   client: Joi.string().allow(null)
 });
+
+const updatePaths = Joi.object();
+
+module.exports = {
+  base,
+  updatePaths
+};

--- a/test/api/handlers/projects/update-paths.js
+++ b/test/api/handlers/projects/update-paths.js
@@ -1,0 +1,113 @@
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+
+var experiment = lab.experiment;
+var test = lab.test;
+var before = lab.before;
+var after = lab.after;
+var expect = require('code').expect;
+
+var db = require('../../../lib/db');
+var config = require('../../../lib/fixtures/projects').updatePaths;
+var server;
+
+before(function(done) {
+  require('../../../lib/mocks/server')(function(obj) {
+    server = obj;
+
+    config(function(err, update) {
+      if (err) { throw err; }
+
+      config = update;
+      done();
+    });
+  });
+});
+
+after(function(done) {
+  server.stop(done);
+});
+
+function getFilePathsForProject(projectId) {
+  return db.select().table('files')
+  .then(function(rows) {
+    var filePaths = [];
+
+    rows.forEach(function(row) {
+      if(row.project_id !== projectId) {
+        return;
+      }
+
+      filePaths.push(row.path);
+    });
+
+    return filePaths;
+  });
+}
+
+// PUT /projects/:project_id/updatepaths
+experiment('[Update file paths for a project due to a folder rename]', function() {
+  test('success case', function(done) {
+    var opts = config.success.default;
+    var filePathsUsed = config.success.filePathsUsed.valid;
+    var oldPaths = Object.keys(filePathsUsed);
+    var newPaths = oldPaths.map(function(oldPath) {
+      return filePathsUsed[oldPath];
+    });
+
+    server.inject(opts, function(resp) {
+      expect(resp.statusCode).to.equal(200);
+
+      getFilePathsForProject(config.success.projectId)
+      .then(function(filePaths) {
+        expect(filePaths).to.not.include(oldPaths);
+        expect(filePaths).to.include(newPaths);
+
+        done();
+      })
+      .catch(done);
+    });
+  });
+
+  test('success case with extra non-existent paths', function(done) {
+    var data = config.success;
+    var opts = data.badPaths;
+    var validFilePathsUsed = data.filePathsUsed.valid;
+    var validOldPaths = Object.keys(validFilePathsUsed);
+    var validNewPaths = validOldPaths.map(function(oldPath) {
+      return validFilePathsUsed[oldPath];
+    });
+    var invalidFilePathsUsed = data.filePathsUsed.invalid;
+    var invalidOldPaths = Object.keys(invalidFilePathsUsed);
+    var invalidNewPaths = invalidOldPaths.map(function(oldPath) {
+      return invalidFilePathsUsed[oldPath];
+    });
+
+    server.inject(opts, function(resp) {
+      expect(resp.statusCode).to.equal(200);
+
+      getFilePathsForProject(data.projectId)
+      .then(function(filePaths) {
+        expect(filePaths).to.not.include(validOldPaths);
+        expect(filePaths).to.include(validNewPaths);
+        expect(filePaths).to.not.include(invalidOldPaths);
+        expect(filePaths).to.not.include(invalidNewPaths);
+
+        done();
+      })
+      .catch(done);
+    });
+  });
+
+  test('project must exist', function(done) {
+    var opts = config.fail.projectDoesNotExist;
+
+    server.inject(opts, function(resp) {
+      expect(resp.statusCode).to.equal(404);
+      expect(resp.result).to.exist();
+      expect(resp.result.error).to.equal('Not Found');
+
+      done();
+    });
+  });
+});

--- a/test/lib/fixtures/files/test-files.js
+++ b/test/lib/fixtures/files/test-files.js
@@ -1,24 +1,17 @@
 var db = require('../../db');
-var files = {};
-
-files.invalid = {
-  id: 'thisisastring',
-  project_id: 'thisisastring',
-  path: 123,
-  buffer: 'thisisastring'
-};
 
 module.exports = function(cb) {
-  if (files.valid) {
-    return cb(null, files);
-  }
-
   db.select().table('files').orderBy('id')
-    .then(function(rows) {
-      files.valid = rows;
-      cb(null, files);
-    })
-    .catch(function(e) {
-      cb(e);
+  .then(function(rows) {
+    cb(null, {
+      valid: rows,
+      invalid: {
+        id: 'thisisastring',
+        project_id: 'thisisastring',
+        path: 123,
+        buffer: 'thisisastring'
+      }
     });
+  })
+  .catch(cb);
 };

--- a/test/lib/fixtures/projects/index.js
+++ b/test/lib/fixtures/projects/index.js
@@ -5,6 +5,7 @@ module.exports = {
   create: require('./create'),
   update: require('./update'),
   delete: require('./delete'),
+  updatePaths: require('./update-paths'),
 
   testProjects: require('./test-projects')
 };

--- a/test/lib/fixtures/projects/test-projects.js
+++ b/test/lib/fixtures/projects/test-projects.js
@@ -1,34 +1,28 @@
 var db = require('../../db');
-var projects = {};
-
-projects.invalid = {
-  id: 'thisisastring',
-  title: 12345,
-  username: 23241,
-  isPublic: null
-};
 
 module.exports = function(cb) {
-  if (projects.valid) {
-    return cb(null, projects);
-  }
-
   db.select().table('projects').orderBy('id')
-    .then(function(rows) {
-      rows.forEach(function(row) {
-        if (row._date_created) {
-          row.date_created = row._date_created.toISOString();
-          delete row._date_created;
-        }
-        if (row._date_updated) {
-          row.date_updated = row._date_updated.toISOString();
-          delete row._date_updated;
-        }
-      });
-      projects.valid = rows;
-      cb(null, projects);
-    })
-    .catch(function(e) {
-      cb(e);
+  .then(function(rows) {
+    rows.forEach(function(row) {
+      if (row._date_created) {
+        row.date_created = row._date_created.toISOString();
+        delete row._date_created;
+      }
+      if (row._date_updated) {
+        row.date_updated = row._date_updated.toISOString();
+        delete row._date_updated;
+      }
     });
+
+    cb(null, {
+      valid: rows,
+      invalid: {
+        id: 'thisisastring',
+        title: 12345,
+        username: 23241,
+        isPublic: null
+      }
+    });
+  })
+  .catch(cb);
 };

--- a/test/lib/fixtures/projects/update-paths.js
+++ b/test/lib/fixtures/projects/update-paths.js
@@ -1,0 +1,72 @@
+var path = require('path');
+
+var retrieveTestProjects = require('./test-projects');
+
+var retrieveTestFiles = require('../files/test-files');
+
+var updatePaths = {};
+var userToken = {
+  authorization: 'token ag-dubs'
+};
+
+module.exports = function(cb) {
+  if (updatePaths.success) {
+    return cb(null, updatePaths);
+  }
+
+  retrieveTestProjects(function(err, projects) {
+    if (err) { return cb(err); }
+
+    var validProject = projects.valid[0];
+
+    retrieveTestFiles(function(err, files) {
+      if (err) { return cb(err); }
+
+      var validFiles = {};
+      var invalidFiles = {
+        '/this/path/is/invalid': '/should/be/ignored'
+      };
+
+      files.valid.forEach(function(file) {
+        if(file.project_id !== validProject.id) {
+          return;
+        }
+
+        validFiles[file.path] = path.join('/renamedfolder', file.path);
+      });
+
+      var validAndInvalidFiles = Object.assign({}, validFiles, invalidFiles);
+
+      updatePaths.success = {
+        default: {
+          headers: userToken,
+          url: '/projects/' + validProject.id + '/updatepaths',
+          method: 'put',
+          payload: validFiles
+        },
+        badPaths: {
+          headers: userToken,
+          url: '/projects/' + validProject.id + '/updatepaths',
+          method: 'put',
+          payload: validAndInvalidFiles
+        },
+        projectId: validProject.id,
+        filePathsUsed: {
+          valid: validFiles,
+          invalid: invalidFiles
+        }
+      };
+
+      updatePaths.fail = {
+        projectDoesNotExist: {
+          headers: userToken,
+          url: '/projects/999999/updatepaths',
+          method: 'put',
+          payload: validFiles
+        }
+      };
+
+      cb(null, updatePaths);
+    });
+  });
+};

--- a/test/lib/fixtures/publishedProjects/test-publishedProjects.js
+++ b/test/lib/fixtures/publishedProjects/test-publishedProjects.js
@@ -1,18 +1,6 @@
 var db = require('../../db');
-var publishedProjects = {};
-
-publishedProjects.invalid = {
-  id: 'thisisastring',
-  title: 12345,
-  date_created: 12345,
-  date_updated: 12345
-};
 
 module.exports = function(callback) {
-  if (publishedProjects.valid) {
-    return callback(null, publishedProjects);
-  }
-
   db.select().table('publishedProjects').orderBy('id')
   .then(function(rows) {
     rows.forEach(function(row) {
@@ -25,8 +13,16 @@ module.exports = function(callback) {
         delete row._date_updated;
       }
     });
-    publishedProjects.valid = rows;
-    callback(null, publishedProjects);
+
+    callback(null, {
+      valid: rows,
+      invalid: {
+        id: 'thisisastring',
+        title: 12345,
+        date_created: 12345,
+        date_updated: 12345
+      }
+    });
   })
   .catch(callback);
 };

--- a/test/lib/fixtures/users/test-users.js
+++ b/test/lib/fixtures/users/test-users.js
@@ -7,16 +7,16 @@ users.invalid = {
 };
 
 module.exports = function(cb) {
-  if (users.valid) {
-    return cb(null, users);
-  }
-
   db.select().from('users').orderBy('id')
-    .then(function(rows) {
-      users.valid = rows;
-      cb(null, users);
-    })
-    .catch(function(e) {
-      cb(e);
+  .then(function(rows) {
+    users.valid = rows;
+    cb(null, {
+      valid: rows,
+      invalid: {
+        id: 'thisisastring',
+        username: 1919
+      }
     });
+  })
+  .catch(cb);
 };


### PR DESCRIPTION
Related to https://github.com/mozilla/thimble.mozilla.org/pull/1504 and https://github.com/mozilla/brackets/pull/558. This adds a new route that accepts a payload of path mappings i.e. `oldPath: newPath` as an object and updates the relevant files with the new paths. 

This needs to land before the corresponding Thimble and Brackets patches.