### PR TITLE
Update Knex and Bookshelf

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "migrate": "knex migrate:latest",
     "seed": "knex seed:run",
     "pretest": "npm run knex && npm run lint",
-    "test": "lab -t 80 -c --verbose --colors --assert code --timeout 5000",
+    "test": "lab -t 80 -c --verbose --colors --assert code --timeout 5000 --leaks",
     "lint": "eslint adaptors api lib server.js"
   },
   "repository": {
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "bluebird": "^2.9.30",
-    "bookshelf": "^0.8.1",
+    "bookshelf": "^0.10.3",
     "boom": "^2.7.2",
     "bunyan": "^1.3.6",
     "bunyan-prettystream": "^0.1.3",
@@ -37,7 +37,7 @@
     "hapi-bunyan": "^0.6.0",
     "hoek": "^2.14.0",
     "joi": "^6.4.3",
-    "knex": "^0.8.6",
+    "knex": "^0.12.9",
     "lout": "^6.2.2",
     "mime": "^1.3.4",
     "newrelic": "^1.39.1",
@@ -49,12 +49,11 @@
     "tar-stream": "^1.2.1"
   },
   "devDependencies": {
-    "code": "^1.4.0",
+    "code": "^4.0.0",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
-    "cross-spawn": "^0.4.0",
     "eslint": "^2.13.1",
-    "lab": "^10.8.2",
+    "lab": "^13.1.0",
     "mofo-style": "^2.4.0",
     "mox-server": "^0.2.0",
     "pg": "^4.5.5"


### PR DESCRIPTION
I updated `code` and `lab` as well to reflect the ORM updates. They should be inconsequential since they're just test framework updates.

`--leaks` needs to be passed into the tests now because of failures in Bookshelf's build (using babel). Tracking issue is https://github.com/tgriesser/bookshelf/issues/1191