### PR TITLE
Cache files for the remix case

### DIFF
--- a/api/classes/base_cache.js
+++ b/api/classes/base_cache.js
@@ -1,11 +1,29 @@
 "use strict";
 
+const Hoek = require(`hoek`);
+
 const DEFAULT_CACHE_EXPIRY_MS = 15 * 60 * 1000;
 const DEFAULT_CACHE_REQUEST_TIMEOUT_MS = 60 * 1000;
 
 class BaseCache {
-  constructor(cache) {
-    this.cache = cache;
+  constructor(server) {
+    if (!server.app.cacheEnabled) {
+      return;
+    }
+
+    // We poll for access to a ready cache client before we can use the cache
+    // since catbox does not expose events to know when the cache client is
+    // ready to use
+    server.once(`start`, () => {
+      const catboxEngine = server.root._caches._default.client.connection;
+      const intervalId = setInterval(() => {
+        if (catboxEngine.isReady()) {
+          Hoek.assert(catboxEngine.client && typeof catboxEngine.client === `object`, `Can't find redis client in Catbox engine`);
+          clearInterval(intervalId);
+          this.cache = catboxEngine.client;
+        }
+      }, 500);
+    });
   }
 
   get name() {

--- a/api/classes/base_cache.js
+++ b/api/classes/base_cache.js
@@ -4,18 +4,22 @@ const DEFAULT_CACHE_EXPIRY_MS = 15 * 60 * 1000;
 const DEFAULT_CACHE_REQUEST_TIMEOUT_MS = 60 * 1000;
 
 class BaseCache {
-  static get name() {
+  constructor(cache) {
+    this.cache = cache;
+  }
+
+  get name() {
     throw new Error(`name property has not been set in subclass`);
   }
 
-  static get config() {
+  get config() {
     return {
       expiresIn: DEFAULT_CACHE_EXPIRY_MS,
       generateTimeout: DEFAULT_CACHE_REQUEST_TIMEOUT_MS
     };
   }
 
-  static run() {
+  run() {
     throw new Error(`run function has not been implemented in subclass or has been called incorrectly`);
   }
 }

--- a/api/classes/prerequisites.js
+++ b/api/classes/prerequisites.js
@@ -85,7 +85,7 @@ class Prerequisites {
         const usernameParam = request.auth.credentials.username;
 
         const result = Promise.fromCallback(next => {
-          return request.server.methods.cache.user(usernameParam, next);
+          return request.server.methods.user(usernameParam, next);
         })
         .then(authenticatedUser => {
           if (!authenticatedUser) {

--- a/api/index.js
+++ b/api/index.js
@@ -5,7 +5,7 @@ const Hoek = require(`hoek`);
 exports.register = function api(server, options, next) {
   const cacheEnabled = !!(process.env.REDIS_URL);
 
-  function api() {
+  function routeSetup() {
     server.register([{
       register: require(`./modules/users/routes`)
     }, {
@@ -79,14 +79,14 @@ exports.register = function api(server, options, next) {
           }
         }
 
-        server.method(cache.name, () => cache.run(), cacheConfig);
+        server.method(cache.name, cache.run.bind(cache), cacheConfig);
       });
     });
   }
 
   if (!cacheEnabled) {
     cacheSetup();
-    api();
+    routeSetup();
     return;
   }
 
@@ -107,7 +107,7 @@ exports.register = function api(server, options, next) {
       Hoek.assert(catboxEngine.client && typeof catboxEngine.client === `object`, `Can't find redis client in Catbox engine`);
       clearInterval(intervalId);
       cacheSetup(catboxEngine.client);
-      api();
+      routeSetup();
     }
   }, 500);
 };

--- a/api/index.js
+++ b/api/index.js
@@ -15,7 +15,7 @@ exports.register = function api(server, options, next) {
         };
       }
 
-      server.method(`cache.${Cache.name}`, Cache.run, cacheConfig);
+      server.method(Cache.name, Cache.run, cacheConfig);
     });
   });
 

--- a/api/index.js
+++ b/api/index.js
@@ -1,87 +1,115 @@
 "use strict";
 
+const Hoek = require(`hoek`);
+
 exports.register = function api(server, options, next) {
-  // Add each module's cache functions to the global server methods
-  [
-    require(`./modules/users/cache`),
-    require(`./modules/files/cache`)
-  ].forEach(module => {
-    Object.keys(module).forEach(CacheClassKey => {
-      const Cache = module[CacheClassKey];
-      let cacheConfig;
+  const cacheEnabled = !!(process.env.REDIS_URL);
 
-      if (process.env.REDIS_URL) {
-        cacheConfig = {
-          cache: Cache.config
-        };
-
-        if (Cache.generateKey) {
-          cacheConfig.generateKey = Cache.generateKey;
-        }
-      }
-
-      server.method(Cache.name, Cache.run, cacheConfig);
-    });
-  });
-
-  server.register(
-    [
-      {
-        register: require(`./modules/users/routes`)
-      },
-      {
-        register: require(`./modules/projects/routes`)
-      },
-      {
-        register: require(`./modules/files/routes`)
-      },
-      {
-        register: require(`./modules/publishedProjects/routes`)
-      },
-      {
-        register: require(`./modules/publishedFiles/routes`)
-      }
-    ], function(err) {
-    if (err) {
-      return next(err);
-    }
-
-    server.route([{
-      method: `GET`,
-      path: `/`,
-      config: {
-        auth: false
-      },
-      handler(request, reply) {
-        return reply(request.generateResponse({
-          name: `publish.webmaker.org`,
-          description: `the publishing service for the Mozilla Leadership Network`,
-          routes: {
-            users: `/users`,
-            projects: `/projects`,
-            files: `/files`,
-            publishedProjects: `/publishedProjects`,
-            publishedFiles: `/publishedFiles`
-          }
-        })
-        .code(200));
-      }
+  function api() {
+    server.register([{
+      register: require(`./modules/users/routes`)
     }, {
-      method: `GET`,
-      path: `/healthcheck`,
-      config: {
-        auth: false
-      },
-      handler(request, reply) {
-        return reply(request.generateResponse({
-          http: `okay`
-        })
-        .code(200));
+      register: require(`./modules/projects/routes`)
+    }, {
+      register: require(`./modules/files/routes`)
+    }, {
+      register: require(`./modules/publishedProjects/routes`)
+    }, {
+      register: require(`./modules/publishedFiles/routes`)
+    }], function(err) {
+      if (err) {
+        return next(err);
       }
-    }]);
 
-    next();
-  });
+      server.route([{
+        method: `GET`,
+        path: `/`,
+        config: {
+          auth: false
+        },
+        handler(request, reply) {
+          return reply(request.generateResponse({
+            name: `publish.webmaker.org`,
+            description: `the publishing service for the Mozilla Leadership Network`,
+            routes: {
+              users: `/users`,
+              projects: `/projects`,
+              files: `/files`,
+              publishedProjects: `/publishedProjects`,
+              publishedFiles: `/publishedFiles`
+            }
+          })
+          .code(200));
+        }
+      }, {
+        method: `GET`,
+        path: `/healthcheck`,
+        config: {
+          auth: false
+        },
+        handler(request, reply) {
+          return reply(request.generateResponse({
+            http: `okay`
+          })
+          .code(200));
+        }
+      }]);
+
+      next();
+    });
+  }
+
+  function cacheSetup(cacheClient) {
+    // Add each module's cache functions to the global server methods
+    [
+      require(`./modules/users/cache`),
+      require(`./modules/files/cache`)
+    ].forEach(module => {
+      Object.keys(module).forEach(CacheClassKey => {
+        const cache = new module[CacheClassKey](cacheClient);
+        let cacheConfig;
+
+        if (cacheEnabled && cache.config) {
+          cacheConfig = {
+            cache: cache.config
+          };
+
+          if (cache.generateKey) {
+            cacheConfig.generateKey = cache.generateKey;
+          }
+        }
+
+        server.method(cache.name, () => cache.run(), cacheConfig);
+      });
+    });
+  }
+
+  if (!cacheEnabled) {
+    cacheSetup();
+    api();
+    return;
+  }
+
+  const catbox = server._caches._default;
+
+  Hoek.assert(catbox && typeof catbox === `object`, `Can't find catbox cache client`);
+
+  const catboxEngine = catbox.connection;
+
+  Hoek.assert(catboxEngine && typeof catboxEngine === `object`, `Can't find catbox engine`);
+  Hoek.assert(typeof catboxEngine.isReady === `function`, `Catbox engine doesn't have a ready function`);
+
+
+  // We poll for access to a ready cache client before continuing since catbox
+  // does not expose events to know when the cache client is ready to use
+  const intervalId = setInterval(() => {
+    if (catboxEngine.isReady()) {
+      Hoek.assert(catboxEngine.client && typeof catboxEngine.client === `object`, `Can't find redis client in Catbox engine`);
+      clearInterval(intervalId);
+      cacheSetup(catboxEngine.client);
+      api();
+    }
+  }, 500);
 };
 
 exports.register.attributes = {

--- a/api/index.js
+++ b/api/index.js
@@ -3,113 +3,91 @@
 const Hoek = require(`hoek`);
 
 exports.register = function api(server, options, next) {
-  const cacheEnabled = !!(process.env.REDIS_URL);
+  if (server.app.cacheEnabled) {
+    const catbox = server.root._caches._default.client;
 
-  function routeSetup() {
-    server.register([{
-      register: require(`./modules/users/routes`)
-    }, {
-      register: require(`./modules/projects/routes`)
-    }, {
-      register: require(`./modules/files/routes`)
-    }, {
-      register: require(`./modules/publishedProjects/routes`)
-    }, {
-      register: require(`./modules/publishedFiles/routes`)
-    }], function(err) {
-      if (err) {
-        return next(err);
+    Hoek.assert(catbox && typeof catbox === `object`, `Can't find catbox cache client`);
+
+    const catboxEngine = catbox.connection;
+
+    Hoek.assert(catboxEngine && typeof catboxEngine === `object`, `Can't find catbox engine`);
+    Hoek.assert(typeof catboxEngine.isReady === `function`, `Catbox engine doesn't have a ready function`);
+  }
+
+  // Add each module's cache functions to the global server methods
+  [
+    require(`./modules/users/cache`),
+    require(`./modules/files/cache`)
+  ].forEach(module => {
+    Object.keys(module).forEach(CacheClassKey => {
+      const cache = new module[CacheClassKey](server);
+      let cacheConfig;
+
+      if (server.app.cacheEnabled && cache.config) {
+        cacheConfig = {
+          cache: cache.config
+        };
+
+        if (cache.generateKey) {
+          cacheConfig.generateKey = cache.generateKey;
+        }
       }
 
-      server.route([{
-        method: `GET`,
-        path: `/`,
-        config: {
-          auth: false
-        },
-        handler(request, reply) {
-          return reply(request.generateResponse({
-            name: `publish.webmaker.org`,
-            description: `the publishing service for the Mozilla Leadership Network`,
-            routes: {
-              users: `/users`,
-              projects: `/projects`,
-              files: `/files`,
-              publishedProjects: `/publishedProjects`,
-              publishedFiles: `/publishedFiles`
-            }
-          })
-          .code(200));
-        }
-      }, {
-        method: `GET`,
-        path: `/healthcheck`,
-        config: {
-          auth: false
-        },
-        handler(request, reply) {
-          return reply(request.generateResponse({
-            http: `okay`
-          })
-          .code(200));
-        }
-      }]);
-
-      next();
+      server.method(cache.name, cache.run.bind(cache), cacheConfig);
     });
-  }
+  });
 
-  function cacheSetup(cacheClient) {
-    // Add each module's cache functions to the global server methods
-    [
-      require(`./modules/users/cache`),
-      require(`./modules/files/cache`)
-    ].forEach(module => {
-      Object.keys(module).forEach(CacheClassKey => {
-        const cache = new module[CacheClassKey](cacheClient);
-        let cacheConfig;
-
-        if (cacheEnabled && cache.config) {
-          cacheConfig = {
-            cache: cache.config
-          };
-
-          if (cache.generateKey) {
-            cacheConfig.generateKey = cache.generateKey;
-          }
-        }
-
-        server.method(cache.name, cache.run.bind(cache), cacheConfig);
-      });
-    });
-  }
-
-  if (!cacheEnabled) {
-    cacheSetup();
-    routeSetup();
-    return;
-  }
-
-  const catbox = server._caches._default;
-
-  Hoek.assert(catbox && typeof catbox === `object`, `Can't find catbox cache client`);
-
-  const catboxEngine = catbox.connection;
-
-  Hoek.assert(catboxEngine && typeof catboxEngine === `object`, `Can't find catbox engine`);
-  Hoek.assert(typeof catboxEngine.isReady === `function`, `Catbox engine doesn't have a ready function`);
-
-
-  // We poll for access to a ready cache client before continuing since catbox
-  // does not expose events to know when the cache client is ready to use
-  const intervalId = setInterval(() => {
-    if (catboxEngine.isReady()) {
-      Hoek.assert(catboxEngine.client && typeof catboxEngine.client === `object`, `Can't find redis client in Catbox engine`);
-      clearInterval(intervalId);
-      cacheSetup(catboxEngine.client);
-      routeSetup();
+  server.register([{
+    register: require(`./modules/users/routes`)
+  }, {
+    register: require(`./modules/projects/routes`)
+  }, {
+    register: require(`./modules/files/routes`)
+  }, {
+    register: require(`./modules/publishedProjects/routes`)
+  }, {
+    register: require(`./modules/publishedFiles/routes`)
+  }], function(err) {
+    if (err) {
+      return next(err);
     }
-  }, 500);
+
+    server.route([{
+      method: `GET`,
+      path: `/`,
+      config: {
+        auth: false
+      },
+      handler(request, reply) {
+        return reply(request.generateResponse({
+          name: `publish.webmaker.org`,
+          description: `the publishing service for the Mozilla Leadership Network`,
+          routes: {
+            users: `/users`,
+            projects: `/projects`,
+            files: `/files`,
+            publishedProjects: `/publishedProjects`,
+            publishedFiles: `/publishedFiles`
+          }
+        })
+        .code(200));
+      }
+    }, {
+      method: `GET`,
+      path: `/healthcheck`,
+      config: {
+        auth: false
+      },
+      handler(request, reply) {
+        return reply(request.generateResponse({
+          http: `okay`
+        })
+        .code(200));
+      }
+    }]);
+
+    next();
+  });
 };
 
 exports.register.attributes = {

--- a/api/index.js
+++ b/api/index.js
@@ -3,7 +3,8 @@
 exports.register = function api(server, options, next) {
   // Add each module's cache functions to the global server methods
   [
-    require(`./modules/users/cache`)
+    require(`./modules/users/cache`),
+    require(`./modules/files/cache`)
   ].forEach(module => {
     Object.keys(module).forEach(CacheClassKey => {
       const Cache = module[CacheClassKey];
@@ -13,6 +14,10 @@ exports.register = function api(server, options, next) {
         cacheConfig = {
           cache: Cache.config
         };
+
+        if (Cache.generateKey) {
+          cacheConfig.generateKey = Cache.generateKey;
+        }
       }
 
       server.method(Cache.name, Cache.run, cacheConfig);

--- a/api/modules/files/cache.js
+++ b/api/modules/files/cache.js
@@ -5,22 +5,18 @@ const Files = require(`./model`);
 const BaseCache = require(`../../classes/base_cache`);
 
 class RemixedFileCreationCache extends BaseCache {
-  static get name() {
+  get name() {
     return `createdRemixFile`;
   }
 
-  static get config() {
-    return Object.assign(super.config, {
-      segment: `file_buffers`
-    });
+  get config() {
+    // We want to override the base config since we want to implement our own
+    // caching process
+    return null;
   }
 
-  // eslint-disable-next-line no-unused-vars
-  static generateKey(fileId, fileBuffer) {
-    return fileId;
-  }
+  run(fileId, fileBuffer, next) {
 
-  static run(fileId, fileBuffer, next) {
     if(typeof fileBuffer !== `function`) {
       return next(null, fileBuffer);
     }

--- a/api/modules/files/cache.js
+++ b/api/modules/files/cache.js
@@ -4,7 +4,25 @@ const Files = require(`./model`);
 
 const BaseCache = require(`../../classes/base_cache`);
 
+const DEFAULT_BUFFER_CACHE_EXPIRY_SEC = 10 * 60;
+
+function getBuffer(fileId, next) {
+  return Files.query({
+    where: {
+      id: fileId
+    },
+    columns: [`buffer`]
+  })
+  .fetch()
+  .then(file => next(null, file && file.get(`buffer`)))
+  .catch(next);
+}
+
 class RemixedFileCreationCache extends BaseCache {
+  constructor(cache) {
+    super(cache);
+  }
+
   get name() {
     return `createdRemixFile`;
   }
@@ -15,25 +33,44 @@ class RemixedFileCreationCache extends BaseCache {
     return null;
   }
 
+  /*
+   * This method takes an optional `fileBuffer` argument
+   * If the `fileBuffer` was passed in, it writes it to cache
+   * If not, the callback is called with a `fileBuffer` retrieved from cache
+   */
   run(fileId, fileBuffer, next) {
+    /*
+     * Putting the file buffer into cache
+     */
 
     if(typeof fileBuffer !== `function`) {
-      return next(null, fileBuffer);
+      if(!this.cache) {
+        return next(null, fileBuffer);
+      }
+
+      return this.cache.setex(`file:${fileId}`, DEFAULT_BUFFER_CACHE_EXPIRY_SEC, fileBuffer)
+      .then(() => next(null, fileBuffer))
+      .catch(next);
     }
 
     next = fileBuffer;
     fileBuffer = null;
 
-    return Files.query({
-      where: {
-        id: fileId
-      },
-      columns: [`buffer`]
-    })
-    .fetch()
-    .then(file => {
-      console.log(`Typeof buffer: `, typeof file.get(`buffer`));
-      next(null, file && file.get(`buffer`));
+    /*
+     * Getting the file buffer from cache
+     */
+
+    if(!this.cache) {
+      return getBuffer(fileId, next);
+    }
+
+    this.cache.getBuffer(`file:${fileId}`)
+    .then(cachedFileBuffer => {
+      if (!cachedFileBuffer) {
+        return getBuffer(fileId, next);
+      }
+
+      next(null, cachedFileBuffer);
     })
     .catch(next);
   }

--- a/api/modules/files/cache.js
+++ b/api/modules/files/cache.js
@@ -45,11 +45,12 @@ class RemixedFileCreationCache extends BaseCache {
 
     if(typeof fileBuffer !== `function`) {
       if(!this.cache) {
+        console.log("NO cache");
         return next(null, fileBuffer);
       }
 
       return this.cache.setex(`file:${fileId}`, DEFAULT_BUFFER_CACHE_EXPIRY_SEC, fileBuffer)
-      .then(() => next(null, fileBuffer))
+      .then(() => { console.log("Setting cache"); next(null, fileBuffer) })
       .catch(next);
     }
 
@@ -67,8 +68,11 @@ class RemixedFileCreationCache extends BaseCache {
     this.cache.getBuffer(`file:${fileId}`)
     .then(cachedFileBuffer => {
       if (!cachedFileBuffer) {
+        console.log("DB HIT FOR FILES");
         return getBuffer(fileId, next);
       }
+
+      console.log("Cache file");
 
       next(null, cachedFileBuffer);
     })

--- a/api/modules/files/cache.js
+++ b/api/modules/files/cache.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const Files = require(`./model`);
+
+const BaseCache = require(`../../classes/base_cache`);
+
+class RemixedFileCreationCache extends BaseCache {
+  static get name() {
+    return `createdRemixFile`;
+  }
+
+  static get config() {
+    return Object.assign(super.config(), {
+      segment: `file_buffers`
+    });
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  static generateKey(fileId, fileBuffer) {
+    return fileId;
+  }
+
+  static run(fileId, fileBuffer, next) {
+    if(typeof fileBuffer !== `function`) {
+      return next(null, fileBuffer);
+    }
+
+    next = fileBuffer;
+    fileBuffer = null;
+
+    return Files.query({
+      where: {
+        id: fileId
+      },
+      columns: [`buffer`]
+    })
+    .fetch()
+    .then(file => {
+      console.log(`Typeof buffer: `, typeof file.get(`buffer`));
+      next(null, file && file.get(`buffer`));
+    })
+    .catch(next);
+  }
+}
+
+module.exports = {
+  RemixedFileCreationCache
+};

--- a/api/modules/files/cache.js
+++ b/api/modules/files/cache.js
@@ -19,8 +19,8 @@ function getBuffer(fileId, next) {
 }
 
 class RemixedFileCreationCache extends BaseCache {
-  constructor(cache) {
-    super(cache);
+  constructor(server) {
+    super(server);
   }
 
   get name() {
@@ -45,12 +45,12 @@ class RemixedFileCreationCache extends BaseCache {
 
     if(typeof fileBuffer !== `function`) {
       if(!this.cache) {
-        console.log("NO cache");
+        console.log(`NO cache, buffer not set in cache`);
         return next(null, fileBuffer);
       }
 
       return this.cache.setex(`file:${fileId}`, DEFAULT_BUFFER_CACHE_EXPIRY_SEC, fileBuffer)
-      .then(() => { console.log("Setting cache"); next(null, fileBuffer) })
+      .then(() => { console.log(`Setting cache`); next(null, fileBuffer) })
       .catch(next);
     }
 
@@ -62,17 +62,18 @@ class RemixedFileCreationCache extends BaseCache {
      */
 
     if(!this.cache) {
+      console.log(`NO Cache. Getting buffer from DB.`);
       return getBuffer(fileId, next);
     }
 
     this.cache.getBuffer(`file:${fileId}`)
     .then(cachedFileBuffer => {
       if (!cachedFileBuffer) {
-        console.log("DB HIT FOR FILES");
+        console.log(`DB HIT FOR FILE`);
         return getBuffer(fileId, next);
       }
 
-      console.log("Cache file");
+      console.log(`CACHE HIT for file`);
 
       next(null, cachedFileBuffer);
     })

--- a/api/modules/files/cache.js
+++ b/api/modules/files/cache.js
@@ -43,14 +43,14 @@ class RemixedFileCreationCache extends BaseCache {
      * Putting the file buffer into cache
      */
 
-    if(typeof fileBuffer !== `function`) {
-      if(!this.cache) {
+    if (typeof fileBuffer !== `function`) {
+      if (!this.cache) {
         console.log(`NO cache, buffer not set in cache`);
         return next(null, fileBuffer);
       }
 
       return this.cache.setex(`file:${fileId}`, DEFAULT_BUFFER_CACHE_EXPIRY_SEC, fileBuffer)
-      .then(() => { console.log(`Setting cache`); next(null, fileBuffer) })
+      .then(() => { console.log(`Setting cache`); next(null, fileBuffer); })
       .catch(next);
     }
 
@@ -61,12 +61,12 @@ class RemixedFileCreationCache extends BaseCache {
      * Getting the file buffer from cache
      */
 
-    if(!this.cache) {
+    if (!this.cache) {
       console.log(`NO Cache. Getting buffer from DB.`);
       return getBuffer(fileId, next);
     }
 
-    this.cache.getBuffer(`file:${fileId}`)
+    return this.cache.getBuffer(`file:${fileId}`)
     .then(cachedFileBuffer => {
       if (!cachedFileBuffer) {
         console.log(`DB HIT FOR FILE`);

--- a/api/modules/files/cache.js
+++ b/api/modules/files/cache.js
@@ -10,7 +10,7 @@ class RemixedFileCreationCache extends BaseCache {
   }
 
   static get config() {
-    return Object.assign(super.config(), {
+    return Object.assign(super.config, {
       segment: `file_buffers`
     });
   }

--- a/api/modules/files/controller.js
+++ b/api/modules/files/controller.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const fs = require(`fs`);
+const Tar = require(`tar-stream`);
 
 const BaseController = require(`../../classes/base_controller`);
 const Errors = require(`../../classes/errors`);
@@ -37,6 +38,38 @@ class FilesController extends BaseController {
     }
 
     return data;
+  }
+
+  getAllAsTar(request, reply) {
+    const files = request.pre.records.models;
+    const tarStream = Tar.pack();
+    const fileCache = request.server.methods.createdRemixFile;
+
+    function processFile(file) {
+      return Promise.fromCallback(next => fileCache(file.get(`id`), next))
+      .then(function(fileBuffer) {
+        return new Promise(function(resolve) {
+          setImmediate(function() {
+            tarStream.entry({
+              name: file.get(`path`)
+            }, fileBuffer);
+
+            resolve();
+          });
+        });
+      });
+    }
+
+    setImmediate(function() {
+      Promise.map(files, processFile, { concurrency: 2 })
+      .then(function() { return tarStream.finalize(); })
+      .catch(Errors.generateErrorResponse);
+    });
+
+    // Normally this type would be application/x-tar, but IE refuses to
+    // decompress a gzipped stream when this is the type.
+    reply(tarStream)
+    .header(`Content-Type`, `application/octet-stream`);
   }
 
   create(request, reply) {

--- a/api/modules/files/controller.js
+++ b/api/modules/files/controller.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const Promise = require(`bluebird`);
 const fs = require(`fs`);
 const Tar = require(`tar-stream`);
 

--- a/api/modules/users/cache.js
+++ b/api/modules/users/cache.js
@@ -21,6 +21,7 @@ class UserCache extends BaseCache {
     })
     .fetch()
     .then(user => {
+      console.log("DB HIT");
       next(null, user && user.toJSON());
     })
     .catch(next);

--- a/api/modules/users/cache.js
+++ b/api/modules/users/cache.js
@@ -5,11 +5,15 @@ const Users = require(`./model`);
 const BaseCache = require(`../../classes/base_cache`);
 
 class UserCache extends BaseCache {
-  static get name() {
+  constructor(cache) {
+    super(cache);
+  }
+
+  get name() {
     return `user`;
   }
 
-  static run(username, next) {
+  run(username, next) {
     return Users.query({
       where: {
         name: username

--- a/api/modules/users/cache.js
+++ b/api/modules/users/cache.js
@@ -5,8 +5,8 @@ const Users = require(`./model`);
 const BaseCache = require(`../../classes/base_cache`);
 
 class UserCache extends BaseCache {
-  constructor(cache) {
-    super(cache);
+  constructor(server) {
+    super(server);
   }
 
   get name() {
@@ -21,7 +21,7 @@ class UserCache extends BaseCache {
     })
     .fetch()
     .then(user => {
-      console.log("DB HIT");
+      console.log(`DB HIT for username`);
       next(null, user && user.toJSON());
     })
     .catch(next);

--- a/server.js
+++ b/server.js
@@ -39,6 +39,8 @@ const server = new Hapi.Server({
   cache
 });
 
+server.app.cacheEnabled = !!process.env.REDIS_URL;
+
 const connection = {
   host: process.env.API_HOST,
   port: process.env.PORT

--- a/test/lib/mocks/server.js
+++ b/test/lib/mocks/server.js
@@ -50,7 +50,7 @@ module.exports = function(done) {
       require(`../../../api/modules/files/cache`)
     ].forEach(module => {
       Object.keys(module).forEach(CacheClassKey => {
-        const cache = new module[CacheClassKey]();
+        const cache = new module[CacheClassKey](server);
 
         server.method(cache.name, cache.run.bind(cache));
       });

--- a/test/lib/mocks/server.js
+++ b/test/lib/mocks/server.js
@@ -46,7 +46,8 @@ module.exports = function(done) {
 
     // Add each module's cache functions to the global server methods
     [
-      require(`../../../api/modules/users/cache`)
+      require(`../../../api/modules/users/cache`),
+      require(`../../../api/modules/files/cache`)
     ].forEach(module => {
       Object.keys(module).forEach(CacheClassKey => {
         const Cache = module[CacheClassKey];
@@ -56,9 +57,13 @@ module.exports = function(done) {
           cacheConfig = {
             cache: Cache.config
           };
+
+          if (Cache.generateKey) {
+            cacheConfig.generateKey = Cache.generateKey;
+          }
         }
 
-        server.method(`cache.${Cache.name}`, Cache.run, cacheConfig);
+        server.method(Cache.name, Cache.run, cacheConfig);
       });
     });
 

--- a/test/lib/mocks/server.js
+++ b/test/lib/mocks/server.js
@@ -50,20 +50,9 @@ module.exports = function(done) {
       require(`../../../api/modules/files/cache`)
     ].forEach(module => {
       Object.keys(module).forEach(CacheClassKey => {
-        const Cache = module[CacheClassKey];
-        let cacheConfig;
+        const cache = new module[CacheClassKey]();
 
-        if (process.env.REDIS_URL) {
-          cacheConfig = {
-            cache: Cache.config
-          };
-
-          if (Cache.generateKey) {
-            cacheConfig.generateKey = Cache.generateKey;
-          }
-        }
-
-        server.method(Cache.name, Cache.run, cacheConfig);
+        server.method(cache.name, cache.run.bind(cache));
       });
     });
 


### PR DESCRIPTION
This patch was becoming unwieldy so I decided to cache publishedFiles in the next patch. In this one, we only cache files when they are created on remixing a project so that we read from cache when we get all the files for the newly remixed project.