### PR TITLE
Cache published files during remix

### DIFF
--- a/api/classes/base_cache.js
+++ b/api/classes/base_cache.js
@@ -40,6 +40,10 @@ class BaseCache {
   run() {
     throw new Error(`run function has not been implemented in subclass or has been called incorrectly`);
   }
+
+  drop() {
+    throw new Error(`drop function has not been implemented in subclass or has been called incorrectly`);
+  }
 }
 
 module.exports = BaseCache;

--- a/api/index.js
+++ b/api/index.js
@@ -17,7 +17,8 @@ exports.register = function api(server, options, next) {
   // Add each module's cache functions to the global server methods
   [
     require(`./modules/users/cache`),
-    require(`./modules/files/cache`)
+    require(`./modules/files/cache`),
+    require(`./modules/publishedFiles/cache`)
   ].forEach(module => {
     Object.keys(module).forEach(CacheClassKey => {
       const cache = new module[CacheClassKey](server);

--- a/api/modules/files/cache.js
+++ b/api/modules/files/cache.js
@@ -45,12 +45,11 @@ class RemixedFileCreationCache extends BaseCache {
 
     if (typeof fileBuffer !== `function`) {
       if (!this.cache) {
-        console.log(`NO cache, buffer not set in cache`);
         return next(null, fileBuffer);
       }
 
       return this.cache.setex(`file:${fileId}`, DEFAULT_BUFFER_CACHE_EXPIRY_SEC, fileBuffer)
-      .then(() => { console.log(`Setting cache`); next(null, fileBuffer); })
+      .then(() => next(null, fileBuffer))
       .catch(next);
     }
 
@@ -62,18 +61,14 @@ class RemixedFileCreationCache extends BaseCache {
      */
 
     if (!this.cache) {
-      console.log(`NO Cache. Getting buffer from DB.`);
       return getBuffer(fileId, next);
     }
 
     return this.cache.getBuffer(`file:${fileId}`)
     .then(cachedFileBuffer => {
       if (!cachedFileBuffer) {
-        console.log(`DB HIT FOR FILE`);
         return getBuffer(fileId, next);
       }
-
-      console.log(`CACHE HIT for file`);
 
       next(null, cachedFileBuffer);
     })

--- a/api/modules/projects/controller.js
+++ b/api/modules/projects/controller.js
@@ -97,7 +97,7 @@ class ProjectsController extends BaseController {
 
   delete(request, reply) {
     const project = request.pre.records.models[0];
-    const publisher = new Publisher(project);
+    const publisher = new Publisher(project, request.server);
     const publishedFilesCleanup = new PublishedFilesCleanup(project);
 
     // If this project is published, we have to
@@ -119,7 +119,7 @@ class ProjectsController extends BaseController {
 
   publish(request, reply) {
     const project = request.pre.records.models[0];
-    const publisher = new Publisher(project);
+    const publisher = new Publisher(project, request.server);
     const readonly = request.query.readonly;
 
     const result = publisher
@@ -135,7 +135,7 @@ class ProjectsController extends BaseController {
 
   unpublish(request, reply) {
     const project = request.pre.records.models[0];
-    const publisher = new Publisher(project);
+    const publisher = new Publisher(project, request.server);
 
     if (!project.attributes.publish_url) {
       return reply(Errors.generateErrorResponse(

--- a/api/modules/publishedFiles/cache.js
+++ b/api/modules/publishedFiles/cache.js
@@ -109,7 +109,6 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
           // FULL Cache hit / NO DB hit
           // Combine the metadata and buffer and return a simple javascript
           // object representation of it
-          console.log(`Cache hit for buffer`);
           publishedFileMeta.buffer = publishedFileBuffer;
           publishedFiles.push(publishedFileMeta);
 
@@ -120,7 +119,6 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
         // Get the buffer from the db
         return this._getBufferFromDB(bufferKeyPrefix, publishedFileId)
         .then(publishedFileBufferFromDB => {
-          console.log(`DB hit for buffer`);
           publishedFileMeta.buffer = publishedFileBufferFromDB;
           publishedFiles.push(publishedFileMeta);
 
@@ -135,7 +133,6 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
 
   run(publishedProjectId, next) {
     if (!this.cache) {
-      console.log(`Cache not enabled`);
       return PublishedFiles.query({
         where: {
           published_id: publishedProjectId
@@ -157,7 +154,6 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
         return this._getAllDataFromDB(metaKey, bufferKeyPrefix, publishedProjectId);
       }
 
-      console.log(`Cache hit for metadata`);
       return this._getAllBuffersFromCache(
         bufferKeyPrefix,
         JSON.parse(publishedFilesMeta)

--- a/api/modules/publishedFiles/cache.js
+++ b/api/modules/publishedFiles/cache.js
@@ -35,7 +35,8 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
     .fetchAll()
     .then(publishedFileModels => {
       // For each published file from the db:
-      // 1. Accumulate a POJO copy of it in an array to be returned back,
+      // 1. Accumulate a simple js object copy of it in an array to be
+      //    returned back,
       // 2. Accumulate the metadata in an array, and
       // 3. Cache its buffer
       return Promise.map(publishedFileModels, publishedFileModel => {
@@ -62,7 +63,7 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
         publishedFilesMeta
       );
     })
-    // Return the array of POJO published files
+    // Return the array of simple js objects of published files
     .then(() => publishedFiles);
   }
 
@@ -93,8 +94,8 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
 
   // PARTIAL or FULL Cache hit / PARTIAL or NO DB hit
   _getAllBuffersFromCache(bufferKeyPrefix, publishedFilesMeta) {
-    // Accumulate all the POJO representations of the published files in an
-    // array to return them
+    // Accumulate all the simple js object representations of the published
+    // files in an array to return them
     return Promise.reduce(publishedFilesMeta, (publishedFiles, publishedFileMeta) => {
       const publishedFileId = publishedFileMeta.id;
 
@@ -103,8 +104,8 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
       .then(publishedFileBuffer => {
         if (publishedFileBuffer) {
           // FULL Cache hit / NO DB hit
-          // Combine the metadata and buffer and return a POJO representation
-          // of it
+          // Combine the metadata and buffer and return a simple javascript
+          // object representation of it
           console.log(`Cache hit for buffer`);
           publishedFileMeta.buffer = publishedFileBuffer;
           publishedFiles.push(publishedFileMeta);
@@ -123,7 +124,10 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
           return publishedFiles;
         });
       });
-    }, []);
+    }, []); // The [] at the end is the accummulator's initial value that will
+    // be populated with the published file simple js objects inside the
+    // callback passed to `reduce()`. It is referred to as `publishedFiles`
+    // inside the callback
   }
 
   run(publishedProjectId, next) {

--- a/api/modules/publishedFiles/cache.js
+++ b/api/modules/publishedFiles/cache.js
@@ -1,0 +1,112 @@
+"use strict";
+
+const PublishedFiles = require(`./model`);
+
+const BaseCache = require(`../../classes/base_cache`);
+
+const PUBLISHED_FILE_CACHE_EXPIRY_MS = 10 * 60 * 1000;
+
+class PublishedFilesByPublishedProjectCache extends BaseCache {
+  constructor(server) {
+    super(server);
+  }
+
+  get name() {
+    return `publishedFilesByPublishedProject`;
+  }
+
+  get config() {
+    return null;
+  }
+
+  run(publishedProjectId, next) {
+    // WIP Need to simplify
+    if (!this.cache) {
+      return PublishedFiles.query({
+        where: {
+          published_id: publishedProjectId
+        }
+      })
+      .fetchAll()
+      .then(publishedFileModels => {
+        return next(null, publishedFileModels.map(model => model.toJSON()));
+      })
+      .catch(next);
+    }
+
+    const metaKey = `publishedProjectFilesMeta:${publishedProjectId}`;
+
+    return this.cache.get(metaKey)
+    .then(publishedFilesMeta => {
+      if (!publishedFilesMeta) {
+        return PublishedFiles.query({
+          where: {
+            published_id: publishedProjectId
+          }
+        })
+        .fetchAll()
+        .then(publishedFileModels => {
+          publishedFilesMeta = [];
+          const publishedFiles = publishedFileModels.map(publishedFileModel => {
+            const publishedFile = publishedFileModel.toJSON();
+
+            publishedFilesMeta.push({
+              id: publishedFile.id,
+              path: publishedFile.path
+            });
+
+            return publishedFile;
+          });
+
+          return this.cache.setex(metaKey, PUBLISHED_FILE_CACHE_EXPIRY_MS, publishedFilesMeta)
+          .then(() => publishedFiles);
+        })
+        .then(publishedFiles => {
+          return Promise.map(publishedFiles, publishedFile => {
+            return this.cache.setex(`publishedFile:${publishedFile.id}`, PUBLISHED_FILE_CACHE_EXPIRY_MS, publishedFile.buffer);
+          })
+          .then(() => next(null, publishedFiles));
+        })
+        .catch(next);
+      }
+
+      return Promise.reduce(publishedFilesMeta, (publishedFiles, publishedFileMeta) => {
+        return this.cache.getBuffer(`publishedFile:${publishedFileMeta.id}`)
+        .then(publishedFileBuffer => {
+          if (!publishedFileBuffer) {
+            // set buffer in cache
+            return PublishedFiles.query({
+              where: {
+                id: publishedFileMeta.id
+              }
+            })
+            .fetch({
+              columns: [`buffer`]
+            })
+            .then(publishedFile => {
+              return this.setex(`publishedFile:${publishedFileMeta.id}`, PUBLISHED_FILE_CACHE_EXPIRY_MS, publishedFile.get(`buffer`))
+              .then(() => {
+                publishedFileMeta.buffer = publishedFileBuffer;
+                publishedFiles.push(publishedFileMeta);
+
+                return publishedFiles;
+              });
+            });
+          }
+
+          publishedFileMeta.buffer = publishedFileBuffer;
+          publishedFiles.push(publishedFileMeta);
+
+          return publishedFiles;
+        });
+      }, [])
+      .then(publishedFiles => next(null, publishedFiles))
+      .catch(next);
+    })
+    .catch(next);
+  }
+}
+
+module.exports = {
+  PublishedFilesByPublishedProjectCache
+};

--- a/api/modules/publishedFiles/cache.js
+++ b/api/modules/publishedFiles/cache.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const Promise = require(`bluebird`);
+
 const PublishedFiles = require(`./model`);
 
 const BaseCache = require(`../../classes/base_cache`);

--- a/api/modules/publishedFiles/cache.js
+++ b/api/modules/publishedFiles/cache.js
@@ -24,7 +24,7 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
   // NO Cache hit / FULL DB hit
   _getAllDataFromDB(metaKey, bufferKeyPrefix, publishedProjectId) {
     const publishedFiles = [];
-    publishedFilesMeta = [];
+    const publishedFilesMeta = [];
 
     // Get all the metadata and buffers from the db with one query
     return PublishedFiles.query({
@@ -115,9 +115,9 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
         // Partial Cache/DB hit
         // Get the buffer from the db
         return this._getBufferFromDB(bufferKeyPrefix, publishedFileId)
-        .then(publishedFileBuffer => {
+        .then(publishedFileBufferFromDB => {
           console.log(`DB hit for buffer`);
-          publishedFileMeta.buffer = publishedFileBuffer;
+          publishedFileMeta.buffer = publishedFileBufferFromDB;
           publishedFiles.push(publishedFileMeta);
 
           return publishedFiles;
@@ -153,7 +153,7 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
       console.log(`Cache hit for metadata`);
       return this._getAllBuffersFromCache(bufferKeyPrefix, publishedFilesMeta);
     })
-    .then(() => next(null, publishedFiles))
+    .then(publishedFiles => next(null, publishedFiles))
     .catch(next);
   }
 }

--- a/api/modules/publishedFiles/cache.js
+++ b/api/modules/publishedFiles/cache.js
@@ -16,12 +16,119 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
   }
 
   get config() {
+    // We want to override the base config since we want to implement our own
+    // caching process
     return null;
   }
 
+  // NO Cache hit / FULL DB hit
+  _getAllDataFromDB(metaKey, bufferKeyPrefix, publishedProjectId) {
+    const publishedFiles = [];
+    publishedFilesMeta = [];
+
+    // Get all the metadata and buffers from the db with one query
+    return PublishedFiles.query({
+      where: {
+        published_id: publishedProjectId
+      }
+    })
+    .fetchAll()
+    .then(publishedFileModels => {
+      // For each published file from the db:
+      // 1. Accumulate a POJO copy of it in an array to be returned back,
+      // 2. Accumulate the metadata in an array, and
+      // 3. Cache its buffer
+      return Promise.map(publishedFileModels, publishedFileModel => {
+        const publishedFile = publishedFileModel.toJSON();
+
+        publishedFiles.push(publishedFile);
+        publishedFilesMeta.push({
+          id: publishedFile.id,
+          path: publishedFile.path
+        });
+
+        return this.cache.setex(
+          `${bufferKeyPrefix}:${publishedFile.id}`,
+          PUBLISHED_FILE_CACHE_EXPIRY_MS,
+          publishedFile.buffer
+        );
+      });
+    })
+    .then(() => {
+      // Cache the accumulated metadata
+      return this.cache.setex(
+        metaKey,
+        PUBLISHED_FILE_CACHE_EXPIRY_MS,
+        publishedFilesMeta
+      );
+    })
+    // Return the array of POJO published files
+    .then(() => publishedFiles);
+  }
+
+  // PARTIAL Cache/DB hit since we only run this function if the buffer does
+  // not exist in the cache
+  _getBufferFromDB(bufferKeyPrefix, publishedFileId) {
+    // Fetch the buffer from the db
+    return PublishedFiles.query({
+      where: {
+        id: publishedFileId
+      }
+    })
+    .fetch({
+      columns: [`buffer`]
+    })
+    .then(publishedFile => {
+      const publishedFileBuffer = publishedFile.get(`buffer`);
+
+      // Cache the buffer before we return it
+      return this.setex(
+        `${bufferKeyPrefix}:${publishedFileId}`,
+        PUBLISHED_FILE_CACHE_EXPIRY_MS,
+        publishedFileBuffer
+      )
+      .then(() => publishedFileBuffer);
+    });
+  }
+
+  // PARTIAL or FULL Cache hit / PARTIAL or NO DB hit
+  _getAllBuffersFromCache(bufferKeyPrefix, publishedFilesMeta) {
+    // Accumulate all the POJO representations of the published files in an
+    // array to return them
+    return Promise.reduce(publishedFilesMeta, (publishedFiles, publishedFileMeta) => {
+      const publishedFileId = publishedFileMeta.id;
+
+      // Attempt to get the buffer from the cache
+      return this.cache.getBuffer(`${bufferKeyPrefix}:${publishedFileId}`)
+      .then(publishedFileBuffer => {
+        if (publishedFileBuffer) {
+          // FULL Cache hit / NO DB hit
+          // Combine the metadata and buffer and return a POJO representation
+          // of it
+          console.log(`Cache hit for buffer`);
+          publishedFileMeta.buffer = publishedFileBuffer;
+          publishedFiles.push(publishedFileMeta);
+
+          return publishedFiles;
+        }
+
+        // Partial Cache/DB hit
+        // Get the buffer from the db
+        return this._getBufferFromDB(bufferKeyPrefix, publishedFileId)
+        .then(publishedFileBuffer => {
+          console.log(`DB hit for buffer`);
+          publishedFileMeta.buffer = publishedFileBuffer;
+          publishedFiles.push(publishedFileMeta);
+
+          return publishedFiles;
+        });
+      });
+    }, []);
+  }
+
   run(publishedProjectId, next) {
-    // WIP Need to simplify
     if (!this.cache) {
+      console.log(`Cache not enabled`);
       return PublishedFiles.query({
         where: {
           published_id: publishedProjectId
@@ -35,74 +142,18 @@ class PublishedFilesByPublishedProjectCache extends BaseCache {
     }
 
     const metaKey = `publishedProjectFilesMeta:${publishedProjectId}`;
+    const bufferKeyPrefix = `publishedFile`;
 
     return this.cache.get(metaKey)
     .then(publishedFilesMeta => {
       if (!publishedFilesMeta) {
-        return PublishedFiles.query({
-          where: {
-            published_id: publishedProjectId
-          }
-        })
-        .fetchAll()
-        .then(publishedFileModels => {
-          publishedFilesMeta = [];
-          const publishedFiles = publishedFileModels.map(publishedFileModel => {
-            const publishedFile = publishedFileModel.toJSON();
-
-            publishedFilesMeta.push({
-              id: publishedFile.id,
-              path: publishedFile.path
-            });
-
-            return publishedFile;
-          });
-
-          return this.cache.setex(metaKey, PUBLISHED_FILE_CACHE_EXPIRY_MS, publishedFilesMeta)
-          .then(() => publishedFiles);
-        })
-        .then(publishedFiles => {
-          return Promise.map(publishedFiles, publishedFile => {
-            return this.cache.setex(`publishedFile:${publishedFile.id}`, PUBLISHED_FILE_CACHE_EXPIRY_MS, publishedFile.buffer);
-          })
-          .then(() => next(null, publishedFiles));
-        })
-        .catch(next);
+        return this._getAllDataFromDB(metaKey, bufferKeyPrefix, publishedProjectId);
       }
 
-      return Promise.reduce(publishedFilesMeta, (publishedFiles, publishedFileMeta) => {
-        return this.cache.getBuffer(`publishedFile:${publishedFileMeta.id}`)
-        .then(publishedFileBuffer => {
-          if (!publishedFileBuffer) {
-            // set buffer in cache
-            return PublishedFiles.query({
-              where: {
-                id: publishedFileMeta.id
-              }
-            })
-            .fetch({
-              columns: [`buffer`]
-            })
-            .then(publishedFile => {
-              return this.setex(`publishedFile:${publishedFileMeta.id}`, PUBLISHED_FILE_CACHE_EXPIRY_MS, publishedFile.get(`buffer`))
-              .then(() => {
-                publishedFileMeta.buffer = publishedFileBuffer;
-                publishedFiles.push(publishedFileMeta);
-
-                return publishedFiles;
-              });
-            });
-          }
-
-          publishedFileMeta.buffer = publishedFileBuffer;
-          publishedFiles.push(publishedFileMeta);
-
-          return publishedFiles;
-        });
-      }, [])
-      .then(publishedFiles => next(null, publishedFiles))
-      .catch(next);
+      console.log(`Cache hit for metadata`);
+      return this._getAllBuffersFromCache(bufferKeyPrefix, publishedFilesMeta);
     })
+    .then(() => next(null, publishedFiles))
     .catch(next);
   }
 }

--- a/api/modules/users/cache.js
+++ b/api/modules/users/cache.js
@@ -21,7 +21,6 @@ class UserCache extends BaseCache {
     })
     .fetch()
     .then(user => {
-      console.log(`DB HIT for username`);
       next(null, user && user.toJSON());
     })
     .catch(next);

--- a/test/lib/mocks/server.js
+++ b/test/lib/mocks/server.js
@@ -47,12 +47,18 @@ module.exports = function(done) {
     // Add each module's cache functions to the global server methods
     [
       require(`../../../api/modules/users/cache`),
-      require(`../../../api/modules/files/cache`)
+      require(`../../../api/modules/files/cache`),
+      require(`../../../api/modules/publishedFiles/cache`)
     ].forEach(module => {
       Object.keys(module).forEach(CacheClassKey => {
         const cache = new module[CacheClassKey](server);
+        const cacheMethod = cache.run.bind(cache);
 
-        server.method(cache.name, cache.run.bind(cache));
+        cacheMethod.cache = {
+          drop: cache.drop.bind(cache)
+        };
+
+        server.method(cache.name, cacheMethod);
       });
     });
 


### PR DESCRIPTION
Builds on https://github.com/mozilla/publish.webmaker.org/pull/248

Had to do a bunch of extra work here since the way we were getting the published files from the db during remix was via a single db query. With caching now, since the publishedFiles is a <b>collection</b> and <b>contains mixed data (json + buffers)</b>, I had to write some extra logic to cache them separately.

### Code logic
Check if the publishedFiles metadata (all metadata stored in one key identified by the published project id) is in cache
   - YES - Fetch it and loop through each publishedFile's metadata and check if the corresponding buffer exists in cache (key being the publishedFileId)
      - YES - [FULL Cache hit / NO DB hit] Fetch it and augment the metadata object with this buffer and add it to the array that will contain all the publishedFiles.
      - NO - [PARTIAL Cache hit / DB hit per missing buffer from cache] Fetch the buffer from the database, write it to cache, and augment the metadata object with this buffer and add it to the array that will contain all the publishedFiles.
      - FINALLY - Return the publishedFiles array to the caller.
   - NO - [NO Cache hit / FULL DB hit - single query to get all publishedFiles] Fetch the publishedFiles (including buffers) from the database. Loop through each model and for each model, 1. Add to an array that will contain only the publishedFile metadata, 2. Write the buffer to the cache, 3. Convert the model to a POJO and add it to an array that will contain the publishedFiles that will be returned to the caller. Once the loop is finished, write the constructed array that contains only the publishedFile metadata to cache and then return the publishedFiles to the caller.

I'm still working on simplifying the code to reflect this logic so this is still a WIP.