### PR TITLE
Inject remix script for HTML document with missing <head> tags

### DIFF
--- a/lib/remix.js
+++ b/lib/remix.js
@@ -22,10 +22,23 @@ function injectMetadata(html, metadata) {
 }
 
 function injectRemixScript(html) {
-  return html.replace(
-    /<\/head/,
-    `<script src="${REMIX_SCRIPT}" type="text/javascript"></script>\n$&`
-  );
+  // Check if <head> tag exists
+  var headTagExist = new RegExp(`<html>[^]*<head>[^]*<\/html>`);
+  var retInject = ``;
+
+  // If they exist, inject remix script before closing </head> tag
+  if (headTagExist.test(html)) {
+    retInject = html.replace(
+      /<\/head/,
+      `  <script src="${REMIX_SCRIPT}" type="text/javascript"></script>\n  $&`);
+  // If they don't exist, add empty <head> and <title> tags, and inject remix script
+  } else {
+    retInject = html.replace(
+      /<html>/,
+      `<html>\n  <head>\n    <title>Untitled<\/title>\n    <script src="${REMIX_SCRIPT}" type="text/javascript"></script>\n  <\/head>`);
+  }
+
+  return retInject;
 }
 
 // Inject the Remix script into the given HTML string


### PR DESCRIPTION
Fixes issue [#2241](https://github.com/mozilla/thimble.mozilla.org/issues/2241)

Before injecting remix script, checks document for `<head>` tags.  If they do not exist, adds empty `<head>` and `<title>` tags:

i.e. https://thimbleprojects.org/jgmac1106/223453/

```html
<!DOCTYPE html>
<header>
  <script src="https://use.fontawesome.com/e83e9b1e77.js"></script>
  <!-- Latest compiled and minified CSS --> 
  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTs
  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
  <!-- Latest compiled and minified JavaScript --> 
  <link href="style.css" rel="stylesheet">
  <script src="https://thimble.mozilla.org/resources/remix/index.js" type="text/javascript"></script>
</header>
<html>
  <body>
   ...
  </body>
</html>
```
replaced with:

```html
<!DOCTYPE html>
<header>
  <script src="https://use.fontawesome.com/e83e9b1e77.js"></script>
  <!-- Latest compiled and minified CSS --> 
  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTs
  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
  <!-- Latest compiled and minified JavaScript --> 
  <link href="style.css" rel="stylesheet">
  <script src="https://thimble.mozilla.org/resources/remix/index.js" type="text/javascript"></script>
</header>
<html>
  <head>
    <title>Untitled</title>
    <script src="http://localhost:3500/resources/remix/index.js" type="text/javascript"></script>
  </head>
  <body>
   ...
  </body>
</html>

```

I also indented the newly added tags since the indentation in bramble editor is 2 spaces.  As far as I could tell, users cannot customise this setting.  @Pomax  Please let me know if this is ok and if you have any other suggestions for this PR.

Thanks