### PR TITLE
Only send the buffer when getting one file

### DIFF
--- a/api/modules/files/controller.js
+++ b/api/modules/files/controller.js
@@ -74,7 +74,7 @@ class FilesController extends BaseController {
   }
 
   getOne(request, reply) {
-    const record = request.pre.records[0];
+    const record = request.pre.records[0].buffer;
 
     reply(
       request.generateResponse(

--- a/test/api/handlers/files/get-one.js
+++ b/test/api/handlers/files/get-one.js
@@ -34,11 +34,8 @@ experiment('[Get one file]', function() {
 
     server.inject(opts, function(resp) {
       expect(resp.statusCode).to.equal(200);
+      expect(resp.headers[`content-type`]).to.equal(`application/octet-stream`);
       expect(resp.result).to.exist();
-      expect(resp.result.id).to.be.a.number();
-      expect(resp.result.project_id).to.not.exist();
-      expect(resp.result.path).to.not.exist();
-      expect(resp.result.buffer).to.be.a.buffer();
 
       done();
     });


### PR DESCRIPTION
Builds on my previous patch. Since Thimble only cares about the buffer in this route, we only send the buffer as an octet-stream instead of bearing the cost os serializing the buffer in a json object.