### PR TITLE
Reduce db calls for project delete

### DIFF
--- a/api/classes/publisher.js
+++ b/api/classes/publisher.js
@@ -21,13 +21,14 @@ const publishedFilesQueryBuilder = require(`../modules/publishedFiles/model`).pr
 const ROOT_URL = `/`;
 const noop = function() {};
 
-function buildUrl(publishClient, user, project) {
+const buildUrl = function(publishClient, user, project) {
   if (!user || !project) {
     return null;
   }
 
+  /* eslint-disable no-use-before-define */
   return process.env.PUBLIC_PROJECT_ENDPOINT + BasePublisher.getUploadRoot(publishClient, user, project);
-}
+};
 
 // Takes an absolute path and uri-encodes each component
 // of the path to return a fully uri safe path
@@ -109,13 +110,13 @@ class BasePublisher {
    */
   static success(type, username) {
     return function(message) {
-      log.info(`Publish ${(username ? `for ${username} ` : "")}- [${type}] ${message}`);
+      log.info(`Publish ${(username ? `for ${username} ` : ``)}- [${type}] ${message}`);
     };
   }
 
   static failure(type, username) {
     return function(error) {
-      log.error({ error }, `Publish ${(username ? `for ${username} ` : "")}- [${type}]`);
+      log.error({ error }, `Publish ${(username ? `for ${username} ` : ``)}- [${type}]`);
       return Promise.reject(error);
     };
   }

--- a/api/classes/publisher.js
+++ b/api/classes/publisher.js
@@ -19,47 +19,14 @@ const publishedProjectsQueryBuilder = PublishedProjects.prototype.queryBuilder()
 const publishedFilesQueryBuilder = require(`../modules/publishedFiles/model`).prototype.queryBuilder();
 
 const ROOT_URL = `/`;
-
-/*
- * Utility functions
- */
-function success(type, username) {
-  return function(message) {
-    log.info(`Publish for ${username} - [${type}] ${message}`);
-  };
-}
-
-function failure(type, username) {
-  return function(error) {
-    log.error({ error }, `Publish for ${username} - [${type}]`);
-    return Promise.reject(error);
-  };
-}
-
-function getUploadRoot(publishClient, user, project) {
-  if (!user || !project) {
-    return null;
-  }
-
-  let httpPrefix = ``;
-  const httpClients = (process.env.HTTP_CLIENTS || ``).split(`,`);
-
-  // If the project's publishing client matches to a list
-  // of "can publish http://" clients, prefix the upload root
-  // /with a special "HTTP" namespace.
-  if (publishClient && httpClients.indexOf(publishClient) !== -1) {
-    httpPrefix = `/HTTP`;
-  }
-
-  return `${httpPrefix}/${user.name}/${project.id}`;
-}
+const noop = function() {};
 
 function buildUrl(publishClient, user, project) {
   if (!user || !project) {
     return null;
   }
 
-  return process.env.PUBLIC_PROJECT_ENDPOINT + getUploadRoot(publishClient, user, project);
+  return process.env.PUBLIC_PROJECT_ENDPOINT + BasePublisher.getUploadRoot(publishClient, user, project);
 }
 
 // Takes an absolute path and uri-encodes each component
@@ -137,6 +104,40 @@ function remove(path) {
 
 
 class BasePublisher {
+  /*
+   * Utility functions
+   */
+  static success(type, username) {
+    return function(message) {
+      log.info(`Publish ${(username ? `for ${username} ` : "")}- [${type}] ${message}`);
+    };
+  }
+
+  static failure(type, username) {
+    return function(error) {
+      log.error({ error }, `Publish ${(username ? `for ${username} ` : "")}- [${type}]`);
+      return Promise.reject(error);
+    };
+  }
+
+  static getUploadRoot(publishClient, user, project) {
+    if (!user || !project) {
+      return null;
+    }
+
+    let httpPrefix = ``;
+    const httpClients = (process.env.HTTP_CLIENTS || ``).split(`,`);
+
+    // If the project's publishing client matches to a list
+    // of "can publish http://" clients, prefix the upload root
+    // /with a special "HTTP" namespace.
+    if (publishClient && httpClients.indexOf(publishClient) !== -1) {
+      httpPrefix = `/HTTP`;
+    }
+
+    return `${httpPrefix}/${user.name}/${project.id}`;
+  }
+
   /**
   * Record fetching helpers
   */
@@ -168,7 +169,7 @@ class BasePublisher {
     .getOne(this.project.published_id)
     .then(publishedProject => {
       this.publishedProject = publishedProject;
-      this.publishRoot = getUploadRoot(
+      this.publishRoot = BasePublisher.getUploadRoot(
         this.project.client,
         this.user,
         publishedProject
@@ -258,7 +259,7 @@ class BasePublisher {
     .then(id => publishedProjectsQueryBuilder.getOne(id))
     .then(publishedProject => {
       this.publishedProject = publishedProject;
-      this.publishRoot = getUploadRoot(
+      this.publishRoot = BasePublisher.getUploadRoot(
         this.project.client,
         this.user,
         publishedProject
@@ -291,8 +292,8 @@ class BasePublisher {
           file.buffer,
           this.remixData
         ))
-        .then(success(`CREATE`, this.user.name))
-        .catch(failure(`CREATE`, this.user.name));
+        .then(BasePublisher.success(`CREATE`, this.user.name))
+        .catch(BasePublisher.failure(`CREATE`, this.user.name));
       });
     });
   }
@@ -317,8 +318,8 @@ class BasePublisher {
           remixData
         );
       })
-      .then(success(`UPDATE`, username))
-      .catch(failure(`UPDATE`, username));
+      .then(BasePublisher.success(`UPDATE`, username))
+      .catch(BasePublisher.failure(`UPDATE`, username));
     }
 
     return publishedFilesQueryBuilder
@@ -382,17 +383,29 @@ class BasePublisher {
     });
   }
 
-  deletePublishedFiles() {
+  // This function deletes the published files on S3 and runs the optional
+  // `deleteSuccessCallback` or `deleteFailureCallback` functions after each
+  // remote deletion. Returns a Promise that is resolved once all published
+  // files have been deleted on S3.
+  static deletePublishedFilesRemotely(publishedProjectId, publishRoot, deleteSuccessCallback = noop, deleteFailureCallback = noop) {
     return publishedFilesQueryBuilder
-    .getAllPaths(this.publishedProject.id)
+    .getAllPaths(publishedProjectId)
     .then(publishedFilePaths => {
       return Promise.map(publishedFilePaths, publishedFilePath => {
-        return remove(this.publishRoot + publishedFilePath)
-        .then(success(`DELETE`, this.user.name))
-        .catch(failure(`DELETE`, this.user.name));
+        return remove(publishRoot + publishedFilePath)
+        .then(deleteSuccessCallback)
+        .catch(deleteFailureCallback);
       });
-    })
-    .then(() => publishedFilesQueryBuilder.deleteAll(this.publishedProject.id));
+    });
+  }
+
+  deletePublishedFiles() {
+    return BasePublisher.deletePublishedFilesRemotely(
+      this.publishedProject.id,
+      this.publishRoot,
+      BasePublisher.success(`DELETE`, this.user.name),
+      BasePublisher.failure(`DELETE`, this.user.name)
+    );
   }
 
   deleteOldFiles() {
@@ -407,8 +420,8 @@ class BasePublisher {
         return publishedFilesQueryBuilder
         .deleteOne(publishedFile.id)
         .then(() => remove(this.publishRoot + publishedFile.path))
-        .then(success(`DELETE`, this.user.name))
-        .catch(failure(`DELETE`, this.user.name));
+        .then(BasePublisher.success(`DELETE`, this.user.name))
+        .catch(BasePublisher.failure(`DELETE`, this.user.name));
       });
     });
   }

--- a/api/modules/projects/controller.js
+++ b/api/modules/projects/controller.js
@@ -9,7 +9,6 @@ const BaseController = require(`../../classes/base_controller`);
 const Publisher = require(`../../classes/publisher`);
 
 const FilesModel = require(`../files/model`);
-const PublishedFilesModel = require(`../publishedFiles/model`);
 
 const ProjectsModel = require(`./model`);
 
@@ -85,21 +84,21 @@ class ProjectsController extends BaseController {
         return publishedProjectsQueryBuilder.deleteOne(publishedProjectId);
       });
     })
-    .then(() => project);;
+    .then(() => project);
   }
 
   delete(request, reply) {
     const project = request.pre.records.models[0];
-    const user = request.pre.user;
+    let user = request.pre.user;
 
     if (!user.name) {
       user = user.toJSON();
     }
 
     return this._deletePublishedProject(project, user)
-    .then(project => {
+    .then(unpublishedProject => {
       const result = Promise.resolve()
-      .then(() => project.destroy())
+      .then(() => unpublishedProject.destroy())
       .then(() => request.generateResponse().code(204))
       .catch(Errors.generateErrorResponse);
 


### PR DESCRIPTION
As discussed on our call, the idea is to reduce the number of db calls when you delete a project.

### Stats
The best case scenario is when the project being deleted is not published while the worst case is when the project being deleted is published.

\# of DB calls before the patch:
- Best - (3 + 2n) where n is the number of files in the project. So for 1 file, (3 + 2) = 5 DB calls
- Worst - (10 + 2n) where n is the number of files in the project. So for 1 file, (10 + 2) = 12 DB calls

\# of DB calls after the patch:
- Best - 2 DB calls (doesn't depend on the number of files)
- Worst - 6 DB calls (doesn't depend on the number of files)

### Test
As an authenticated user, see if you can delete a project that is not published, a project that is published, delete multiple projects at the same time, unpublishing a project (not deleting it).