### PR TITLE
Use caching for users in prerequisite functions

### DIFF
--- a/api/classes/prerequisites.js
+++ b/api/classes/prerequisites.js
@@ -127,7 +127,7 @@ class Prerequisites {
   }
 
   /**
-  * validateOwnership([recordsAreNotModels, fetchUser])
+  * validateOwnership([recordsAreNotModels, fetchUser, userIsNotModel])
   *
   * Ensures the authenticated user is the owner of the
   * resource being manipulated or requested.
@@ -139,11 +139,14 @@ class Prerequisites {
   * owns the resource represented by the simple javascript object in the
   * request prerequisites. This function is required if recordsAreNotModels
   * is set to true
+  * @param {boolean} userIsNotModel - If true, indicates that the user returned
+  * by the `fetchUser` function is not a Bookshelf Model but a simple
+  * javascript object representation of one.
   *
   * @return {Promise} - Promise fullfilled when the user has been confirmed to
   * be the owner of the resource requested
   */
-  static validateOwnership(recordsAreNotModels, fetchUser) {
+  static validateOwnership(recordsAreNotModels, fetchUser, userIsNotModel) {
     if (recordsAreNotModels && typeof fetchUser !== `function`) {
       throw new Error(`fetchUser needs to be a function provided if recordsAreNotModels is set to true`);
     }
@@ -156,8 +159,8 @@ class Prerequisites {
 
         const result = Promise.resolve()
         .then(function() {
-          if (recordsAreNotModels) {
-            return fetchUser(resource);
+          if (typeof fetchUser === `function`) {
+            return fetchUser(resource, request.server);
           }
 
           // Check if the resource is the owning user, otherwise fetch
@@ -179,7 +182,7 @@ class Prerequisites {
           return owner;
         })
         .then(function(owner) {
-          const ownerId = recordsAreNotModels ? owner.id : owner.get(`id`);
+          const ownerId = userIsNotModel ? owner.id : owner.get(`id`);
 
           if (ownerId !== authenticatedUser.id) {
             throw Boom.unauthorized(null, {

--- a/api/classes/publisher.js
+++ b/api/classes/publisher.js
@@ -13,7 +13,6 @@ const Projects = require(`../modules/projects/model`);
 const PublishedProjects = require(`../modules/publishedProjects/model`);
 
 // SQL Query Generators
-const usersQueryBuilder = require(`../modules/users/model`).prototype.queryBuilder();
 const projectsQueryBuilder = Projects.prototype.queryBuilder();
 const publishedProjectsQueryBuilder = PublishedProjects.prototype.queryBuilder();
 const publishedFilesQueryBuilder = require(`../modules/publishedFiles/model`).prototype.queryBuilder();
@@ -156,8 +155,9 @@ class BasePublisher {
   }
 
   fetchUserForProject() {
-    return usersQueryBuilder
-    .getOne(this.project.user_id)
+    return Promise.fromCallback(next => {
+      return this.server.methods.userForProject(this.project.id, next);
+    })
     .then(user => {
       this.user = user;
 

--- a/api/index.js
+++ b/api/index.js
@@ -43,6 +43,18 @@ exports.register = function api(server, options, next) {
             drop: cache.drop.bind(cache)
           };
         }
+      } else {
+        // We stub the drop method if cache is disabled since Hapi does not
+        // provide the API for it
+        cacheMethod.cache = {
+          drop(...args) {
+            const callback = args[args.length - 1];
+
+            if (typeof callback === `function`) {
+              callback();
+            }
+          }
+        };
       }
 
       server.app.cacheContexts[cache.name] = cache;

--- a/api/modules/files/model.js
+++ b/api/modules/files/model.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const Promise = require(`bluebird`);
+
 const BaseModel = require(`../../classes/base_model`);
 
 const ProjectsModel = require(`../projects/model`);
@@ -68,7 +70,10 @@ const classProps = {
   relations: [
     `project`,
     `user`
-  ]
+  ],
+  userForFile(file, server) {
+    return Promise.fromCallback(next => server.methods.userForProject(file.get(`project_id`), next));
+  }
 };
 
 module.exports = BaseModel.extend(instanceProps, classProps);

--- a/api/modules/files/routes/create.js
+++ b/api/modules/files/routes/create.js
@@ -1,12 +1,18 @@
 "use strict";
 
+const Promise = require(`bluebird`);
+
 const Prerequistes = require(`../../../classes/prerequisites`);
 const Errors = require(`../../../classes/errors`);
 
-const ProjectsModel = require(`../../projects/model`);
-
 const schema = require(`../schema`);
 const filesController = require(`../controller`);
+
+function getUserForProject(request) {
+  return Promise.fromCallback(next => {
+    return request.server.methods.userForProject(request.payload.project_id, next);
+  });
+}
 
 module.exports = [{
   method: `POST`,
@@ -20,7 +26,7 @@ module.exports = [{
     },
     pre: [
       Prerequistes.trackTemporaryFile(),
-      Prerequistes.validateCreationPermission(`project_id`, ProjectsModel)
+      Prerequistes.validateCreationPermission(getUserForProject)
     ],
     handler: filesController.create.bind(filesController),
     description: `Create a new file object.`,

--- a/api/modules/files/routes/delete.js
+++ b/api/modules/files/routes/delete.js
@@ -15,10 +15,11 @@ module.exports = [{
     pre: [
       Prerequistes.confirmRecordExists(FilesModel, {
         mode: `param`,
-        requestKey: `id`
+        requestKey: `id`,
+        columns: [`id`, `project_id`]
       }),
       Prerequistes.validateUser(),
-      Prerequistes.validateOwnership()
+      Prerequistes.validateOwnership(false, FilesModel.userForFile, true)
     ],
     handler: filesController.delete.bind(filesController),
     description: `Delete a single file object based on \`id\`.`,

--- a/api/modules/files/routes/read.js
+++ b/api/modules/files/routes/read.js
@@ -37,7 +37,7 @@ module.exports = [{
       }),
       Prerequisites.validateUser(),
       Prerequisites.validateOwnership(true, fileObj => fileQueryBuilder
-  .getUserForFileById(fileObj.id))
+  .getUserForFileById(fileObj.id), true)
     ],
     handler: filesController.getOne.bind(filesController),
     description: `Retrieve a single file object based on \`id\`.`,
@@ -81,7 +81,7 @@ module.exports = [{
         columns: [`id`, `project_id`, `path`]
       }),
       Prerequisites.validateUser(),
-      Prerequisites.validateOwnership()
+      Prerequisites.validateOwnership(false, FilesModel.userForFile, true)
     ],
     handler: filesController.getAllAsMeta.bind(filesController),
     description: `Retrieve a collection of file objects that belong to ` +

--- a/api/modules/files/routes/update.js
+++ b/api/modules/files/routes/update.js
@@ -23,10 +23,11 @@ module.exports = [{
       Prerequisites.trackTemporaryFile(),
       Prerequisites.confirmRecordExists(FilesModel, {
         mode: `param`,
-        requestKey: `id`
+        requestKey: `id`,
+        columns: [`id`, `path`, `project_id`]
       }),
       Prerequisites.validateUser(),
-      Prerequisites.validateOwnership()
+      Prerequisites.validateOwnership(false, FilesModel.userForFile, true)
     ],
     handler: filesController.update.bind(filesController),
     description: `Update a single file object based on \`id\`.`,

--- a/api/modules/projects/controller.js
+++ b/api/modules/projects/controller.js
@@ -89,6 +89,7 @@ class ProjectsController extends BaseController {
 
   delete(request, reply) {
     const project = request.pre.records.models[0];
+    const projectId = project.get(`id`);
     let user = request.pre.user;
 
     if (!user.name) {
@@ -97,6 +98,9 @@ class ProjectsController extends BaseController {
 
     const result = this._deletePublishedProject(project, user)
     .then(unpublishedProject => unpublishedProject.destroy())
+    .then(() => Promise.fromCallback(
+      next => request.server.methods.userForProject.cache.drop(projectId, next)
+    ))
     .then(() => request.generateResponse().code(204))
     .catch(Errors.generateErrorResponse);
 

--- a/api/modules/projects/model.js
+++ b/api/modules/projects/model.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const Promise = require(`bluebird`);
+
 const BaseModel = require(`../../classes/base_model`);
 const UsersModel = require(`../users/model`);
 
@@ -89,7 +91,10 @@ const classProps = {
   relations: [
     `user`,
     `files`
-  ]
+  ],
+  userForProject(project, server) {
+    return Promise.fromCallback(next => server.methods.userForProject(project.get(`id`), next));
+  }
 };
 
 module.exports = BaseModel.extend(instanceProps, classProps);

--- a/api/modules/projects/model.js
+++ b/api/modules/projects/model.js
@@ -1,13 +1,15 @@
 "use strict";
 
 const BaseModel = require(`../../classes/base_model`);
+const UsersModel = require(`../users/model`);
 
 const DateTracker = require(`../../../lib/utils`).DateTracker;
 
 class ProjectsQueryBuilder {
-  constructor(context) {
+  constructor(context, usersTable) {
     this.context = context;
     this.ProjectsModel = context.constructor;
+    this.usersTable = usersTable;
   }
 
   getOne(id) {
@@ -23,6 +25,33 @@ class ProjectsQueryBuilder {
     .where(this.context.column(`id`), id)
     .update(this.context.format(updatedValues))
     .then(function() { return id; });
+  }
+
+  getUserByProjectId(id) {
+    return new this.ProjectsModel()
+    .query()
+    .innerJoin(
+      this.usersTable.tableName,
+      this.context.column(`user_id`),
+      this.usersTable.column(`id`)
+    )
+    .where(this.context.column(`id`), id)
+    .select(
+      this.context.column(`id`, `project_id`),
+      this.usersTable.column(`id`),
+      this.usersTable.column(`name`)
+    )
+    .then(function(projectWithUser) {
+      if (!projectWithUser || projectWithUser.length < 1) {
+        return;
+      }
+
+      const user = projectWithUser[0];
+
+      delete user.project_id;
+
+      return user;
+    });
   }
 }
 
@@ -46,7 +75,7 @@ const instanceProps = {
   format: DateTracker.formatDatesInModel,
   parse: DateTracker.parseDatesInModel,
   queryBuilder() {
-    return new ProjectsQueryBuilder(this);
+    return new ProjectsQueryBuilder(this, UsersModel.prototype);
   }
 };
 

--- a/api/modules/projects/routes/delete.js
+++ b/api/modules/projects/routes/delete.js
@@ -18,7 +18,7 @@ module.exports = [{
         requestKey: `id`
       }),
       Prerequisites.validateUser(),
-      Prerequisites.validateOwnership()
+      Prerequisites.validateOwnership(false, ProjectsModel.userForProject, true)
     ],
     handler: projectsController.delete.bind(projectsController),
     description: `Delete a single project object based on \`id\`.`,

--- a/api/modules/projects/routes/publish.js
+++ b/api/modules/projects/routes/publish.js
@@ -19,7 +19,7 @@ module.exports = [{
         requestKey: `id`
       }),
       Prerequisites.validateUser(),
-      Prerequisites.validateOwnership()
+      Prerequisites.validateOwnership(false, ProjectsModel.userForProject, true)
     ],
     handler: projectsController.publish.bind(projectsController),
     description: `Publish a project.`,
@@ -37,7 +37,7 @@ module.exports = [{
         requestKey: `id`
       }),
       Prerequisites.validateUser(),
-      Prerequisites.validateOwnership()
+      Prerequisites.validateOwnership(false, ProjectsModel.userForProject, true)
     ],
     handler: projectsController.unpublish.bind(projectsController),
     description: `Unpublish a project.`

--- a/api/modules/projects/routes/read.js
+++ b/api/modules/projects/routes/read.js
@@ -18,7 +18,7 @@ module.exports = [{
         requestKey: `id`
       }),
       Prerequisites.validateUser(),
-      Prerequisites.validateOwnership()
+      Prerequisites.validateOwnership(false, ProjectsModel.userForProject, true)
     ],
     handler: projectsController.getOne.bind(projectsController),
     description: `Retrieve a single project object based on \`id\`.`,
@@ -39,7 +39,7 @@ module.exports = [{
         requestKey: `user_id`
       }),
       Prerequisites.validateUser(),
-      Prerequisites.validateOwnership()
+      Prerequisites.validateOwnership(false, ProjectsModel.userForProject, true)
     ],
     handler: projectsController.getAll.bind(projectsController),
     description: `Retrieve a collection of project objects belonging to a single user object, based on \`user_id\`.`,

--- a/api/modules/projects/routes/update-paths.js
+++ b/api/modules/projects/routes/update-paths.js
@@ -26,7 +26,7 @@ module.exports = [{
         requestKey: `id`
       }),
       Prerequisites.validateUser(),
-      Prerequisites.validateOwnership()
+      Prerequisites.validateOwnership(false, ProjectsModel.userForProject, true)
     ],
     handler: projectsController.updatePaths.bind(projectsController),
     description: `Update all file paths belonging to a project whose \`id\` ` +

--- a/api/modules/projects/routes/update.js
+++ b/api/modules/projects/routes/update.js
@@ -19,7 +19,7 @@ module.exports = [{
         requestKey: `id`
       }),
       Prerequisites.validateUser(),
-      Prerequisites.validateOwnership()
+      Prerequisites.validateOwnership(false, ProjectsModel.userForProject, true)
     ],
     handler: projectsController.update.bind(projectsController),
     description: `Update a single project object based on \`id\`.`,

--- a/api/modules/users/cache.js
+++ b/api/modules/users/cache.js
@@ -13,6 +13,12 @@ class UserCache extends BaseCache {
     return `user`;
   }
 
+  get config() {
+    return Object.assign(super.config, {
+      expiresIn: 60 * 60 * 1000 // 1 hour, an approximation of a typical user's Thimble session
+    });
+  }
+
   run(username, next) {
     return Users.query({
       where: {

--- a/test/lib/mocks/server.js
+++ b/test/lib/mocks/server.js
@@ -57,7 +57,13 @@ module.exports = function(done) {
         const cacheMethod = cache.run.bind(cache);
 
         cacheMethod.cache = {
-          drop: cache.drop.bind(cache)
+          drop(...args) {
+            const next = args[args.length - 1];
+
+            if (typeof next === `function`) {
+              next();
+            }
+          }
         };
 
         server.app.cacheContexts[cache.name] = cache;


### PR DESCRIPTION
This patch does ~two~ three things:
1. Uses the `username (returns) user`  cache to get the user for the current request (based on auth data) for creating a resource.
2. Adds a cache layer for `project_id (returns) user` so that it can be used in two places - one when we want to make sure that a user attempting to create a file for a project actually owns that project. and two when we publish to get the user for the project so that we can construct the publish url based on the user name.
3. The `project_id (returns) user` cache layer is also used in the prerequisite function `valudateOwnership` for multiple file and project operations.

To test this, add:
to `api/classes/database.js`
```js
Knex.on('query', data => console.log(data.sql) );
```
and to `api/index.js`
```js
server.on('request-internal', (request, event, tags) => {
    if (tags.received) {
        console.log(`-------------- ${request.method.toUpperCase()} :: ${request.url.href} --------------`);
    }
});
```

and make sure that when you create new files after creating a new project, it doesn't select a user from the db.