### PR TITLE
Fix promise resolution in route handlers

### DIFF
--- a/api/modules/files/controller.js
+++ b/api/modules/files/controller.js
@@ -142,11 +142,13 @@ class FilesController extends BaseController {
   }
 
   update(request, reply) {
-    return Promise.fromCallback(next => {
+    const result = Promise.fromCallback(next => {
       return request.server.methods.file.cache.drop(request.params.id, next);
     })
-    .then(() => super.update(request, reply, formatResponse))
-    .catch(error => reply(Errors.generateErrorResponse(error)));
+    .then(() => super._update(request, reply, formatResponse))
+    .catch(Errors.generateErrorResponse);
+
+    return reply(result);
   }
 
   delete(request, reply) {
@@ -154,7 +156,7 @@ class FilesController extends BaseController {
 
     // If a published file exists for this file, we have
     // to unset it's reference before deletion can occur
-    PublishedFiles.query({
+    const result = PublishedFiles.query({
       where: {
         file_id: record.get(`id`)
       }
@@ -174,8 +176,10 @@ class FilesController extends BaseController {
         return request.server.methods.file.cache.drop(request.params.id, next);
       });
     })
-    .then(() => super.delete(request, reply))
-    .catch(function(error) { reply(Errors.generateErrorResponse(error)); });
+    .then(() => super._delete(request, reply))
+    .catch(Errors.generateErrorResponse);
+
+    return reply(result);
   }
 }
 


### PR DESCRIPTION
Unfortunately, I don't have a way to test this locally. This only breaks on prod and staging.

Before, we did not return a promise chain from some of our handlers and called the reply interface in an inherited handler which I think made hapi not wait on the initial promise to complete. This makes sure that we always only pass in one promise chain into the reply interface and also separates the create/update/delete db logic from the actual HTTP logic.

This should hopefully fix mozilla/thimble.mozilla.org#2441