### PR TITLE
Add routes to export project data and metadata

### DIFF
--- a/api/classes/base_controller.js
+++ b/api/classes/base_controller.js
@@ -88,13 +88,8 @@ class BaseController {
     );
   }
 
-  // NOTE: creating the tarball for a project can be a lengthy process, so
-  // we do it in multiple turns of the event loop, so that other requests
-  // don't get blocked.
-  getAllAsTar(request, reply) {
-    const files = request.pre.records.models;
+  _getFileTarStream(Model, files, concurrency=2) {
     const tarStream = Tar.pack();
-    const Model = this.Model;
 
     function processFile(file) {
       return Model.query({
@@ -108,9 +103,7 @@ class BaseController {
         return new Promise(function(resolve) {
           setImmediate(function() {
             tarStream.entry(
-              {
-                name: file.get(`path`)
-              },
+              { name: file.get(`path`) },
               model.get(`buffer`)
             );
 
@@ -121,14 +114,23 @@ class BaseController {
     }
 
     setImmediate(function() {
-      Promise.map(files, processFile, { concurrency: 2 })
+      Promise.map(files, processFile, { concurrency })
       .then(function() { return tarStream.finalize(); })
       .catch(Errors.generateErrorResponse);
     });
 
+    return tarStream;
+  }
+
+  // NOTE: creating the tarball for a project can be a lengthy process, so
+  // we do it in multiple turns of the event loop, so that other requests
+  // don't get blocked.
+  getAllAsTar(request, reply) {
+    const files = request.pre.records.models;
+
     // Normally this type would be application/x-tar, but IE refuses to
     // decompress a gzipped stream when this is the type.
-    reply(tarStream)
+    return reply(this._getFileTarStream(this.Model, files))
     .header(`Content-Type`, `application/octet-stream`);
   }
 
@@ -180,6 +182,19 @@ class BaseController {
 
   delete(request, reply) {
     return reply(this._delete(request, reply));
+  }
+
+  exportProjectMetadata(request, reply) {
+    const {
+      title,
+      description,
+      _date_created: dateCreated,
+      _date_updated: dateUpdated
+    } = request.pre.records.models[0].toJSON();
+
+    return reply(request.generateResponse({
+      title, description, dateCreated, dateUpdated
+    }));
   }
 }
 

--- a/api/classes/base_export_cache.js
+++ b/api/classes/base_export_cache.js
@@ -59,7 +59,7 @@ class ExportCache extends BaseCache {
           throw new Error(`Token ${saltedToken} provided for ${this.resourceName} is invalid`);
         }
 
-        return next(null, cachedId);
+        return next(null, parseInt(cachedId));
       })
       .catch(next);
     }
@@ -75,7 +75,7 @@ class ExportCache extends BaseCache {
       return next(null, id);
     }
 
-    Tokenizer.generate((err, generatedToken) => {
+    return Tokenizer.generate((err, generatedToken) => {
       if (err) {
         return next(err);
       }

--- a/api/modules/projects/controller.js
+++ b/api/modules/projects/controller.js
@@ -197,6 +197,25 @@ class ProjectsController extends BaseController {
       .catch(Errors.generateErrorResponse)
     );
   }
+
+  exportProjectData(request, reply) {
+    const project = request.pre.records.models[0];
+
+    return reply(FilesModel.query({
+      where: {
+        project_id: project.get(`id`)
+      }
+    })
+    .fetchAll({ columns: [`id`, `path`] })
+    .then(files => {
+      if (!files) {
+        files = [];
+      }
+
+      return this._getFileTarStream(FilesModel, files);
+    }))
+    .header(`Content-Type`, `application/octet-stream`);
+  }
 }
 
 module.exports = new ProjectsController();

--- a/api/modules/projects/routes/export.js
+++ b/api/modules/projects/routes/export.js
@@ -29,4 +29,46 @@ module.exports = [{
       failAction: Errors.id
     }
   }
+}, {
+  method: `GET`,
+  path: `/projects/{id}/export/metadata`,
+  config: {
+    auth: `projectToken`,
+    pre: [
+      Prerequisites.confirmRecordExists(ProjectsModel, {
+        mode: `param`,
+        requestKey: `id`
+      }),
+      Prerequisites.validateExportPermission()
+    ],
+    handler: projectsController.exportProjectMetadata.bind(projectsController),
+    description: `Export metadata for a project.`,
+    validate: {
+      params: {
+        id: Joi.number().integer().required()
+      },
+      failAction: Errors.id
+    }
+  }
+}, {
+  method: `GET`,
+  path: `/projects/{id}/export/data`,
+  config: {
+    auth: `projectToken`,
+    pre: [
+      Prerequisites.confirmRecordExists(ProjectsModel, {
+        mode: `param`,
+        requestKey: `id`
+      }),
+      Prerequisites.validateExportPermission()
+    ],
+    handler: projectsController.exportProjectData.bind(projectsController),
+    description: `Export file data for a project.`,
+    validate: {
+      params: {
+        id: Joi.number().integer().required()
+      },
+      failAction: Errors.id
+    }
+  }
 }];

--- a/api/modules/publishedProjects/controller.js
+++ b/api/modules/publishedProjects/controller.js
@@ -7,6 +7,7 @@ const Errors = require(`../../classes/errors`);
 
 const ProjectsModel = require(`../projects/model`);
 const FilesModel = require(`../files/model`);
+const PublishedFilesModel = require(`../publishedFiles/model`);
 
 const PublishedProjectsModel = require(`./model`);
 
@@ -118,6 +119,25 @@ class PublishedProjectsController extends BaseController {
       .then(token => request.generateResponse({ token }).code(201))
       .catch(Errors.generateErrorResponse)
     );
+  }
+
+  exportProjectData(request, reply) {
+    const publishedProject = request.pre.records.models[0];
+
+    return reply(PublishedFilesModel.query({
+      where: {
+        published_id: publishedProject.get(`id`)
+      }
+    })
+    .fetchAll({ columns: [`id`, `path`] })
+    .then(publishedFiles => {
+      if (!publishedFiles) {
+        publishedFiles = [];
+      }
+
+      return this._getFileTarStream(PublishedFilesModel, publishedFiles);
+    }))
+    .header(`Content-Type`, `application/octet-stream`);
   }
 }
 

--- a/api/modules/publishedProjects/routes/export.js
+++ b/api/modules/publishedProjects/routes/export.js
@@ -29,4 +29,46 @@ module.exports = [{
       failAction: Errors.id
     }
   }
+}, {
+  method: `GET`,
+  path: `/publishedprojects/{id}/export/metadata`,
+  config: {
+    auth: `publishedProjectToken`,
+    pre: [
+      Prerequisites.confirmRecordExists(PublishedProjectsModel, {
+        mode: `param`,
+        requestKey: `id`
+      }),
+      Prerequisites.validateExportPermission()
+    ],
+    handler: publishedProjectsController.exportProjectMetadata.bind(publishedProjectsController),
+    description: `Export metadata for a published project.`,
+    validate: {
+      params: {
+        id: Joi.number().integer().required()
+      },
+      failAction: Errors.id
+    }
+  }
+}, {
+  method: `GET`,
+  path: `/publishedprojects/{id}/export/data`,
+  config: {
+    auth: `publishedProjectToken`,
+    pre: [
+      Prerequisites.confirmRecordExists(PublishedProjectsModel, {
+        mode: `param`,
+        requestKey: `id`
+      }),
+      Prerequisites.validateExportPermission()
+    ],
+    handler: publishedProjectsController.exportProjectData.bind(publishedProjectsController),
+    description: `Export published file data for a published project.`,
+    validate: {
+      params: {
+        id: Joi.number().integer().required()
+      },
+      failAction: Errors.id
+    }
+  }
 }];

--- a/server.js
+++ b/server.js
@@ -105,30 +105,30 @@ server.register(require(`./adaptors/plugins`), function(err) {
       validateFunc: tokenValidators.exportPublishedProjectTokenValidator
     }
   );
-});
 
-server.register({ register: require(`./api`) }, function(apiRegisterError) {
-  if (apiRegisterError) {
-    server.log(`error`, {
-      message: `Error registering api`,
-      error: apiRegisterError
-    });
-    throw apiRegisterError;
-  }
-
-  // Server extension hooks
-  server.ext(`onPreResponse`, [extensions.logRequest, extensions.clearTemporaryFile]);
-
-  server.start(function(serverStartError) {
-    if (serverStartError) {
+  server.register({ register: require(`./api`) }, function(apiRegisterError) {
+    if (apiRegisterError) {
       server.log(`error`, {
-        message: `Error starting server`,
-        error: serverStartError
+        message: `Error registering api`,
+        error: apiRegisterError
       });
-      throw serverStartError;
+      throw apiRegisterError;
     }
 
-    server.log(`info`, { server: server.info }, `Server started`);
+    // Server extension hooks
+    server.ext(`onPreResponse`, [extensions.logRequest, extensions.clearTemporaryFile]);
+
+    server.start(function(serverStartError) {
+      if (serverStartError) {
+        server.log(`error`, {
+          message: `Error starting server`,
+          error: serverStartError
+        });
+        throw serverStartError;
+      }
+
+      server.log(`info`, { server: server.info }, `Server started`);
+    });
   });
 });
 


### PR DESCRIPTION
Fix mozilla/thimble.mozilla.org#2669

To Test:
1. Run id/login/thimble (no need to run brackets). Add ``` console.log(`Token: ${token}`);``` to [this line in the Thimble code](https://github.com/mozilla/thimble.mozilla.org/blob/master/server/lib/middleware.js#L99).
2. Run a redis server and set the `REDIS_URL=http://0.0.0.0:6379` in your env for the publish server.
3. Run publish and login to Thimble. Copy the token that was logged in the thimble server. Make sure that project with id 1 is shown in your "My Projects" list in Thimble.
4. Run the following command and replace `<token>` with the copied token. Make sure the response you get back has a token in it (and copy the token value).
```
curl -X POST -H 'Authorization: token <token>' -v -i 'http://localhost:2015/projects/1/export/start'
```
5. Use the token value to run the following request:
```
curl -X GET -H 'Authorization: export <token>' -v -i 'http://localhost:2015/projects/1/export/data'
```
and replace the `<token>` with the token you copied in the last step. Make sure that it returns back the `title` and `description` in the json payload.